### PR TITLE
Content tweaks, Signature & Parameters

### DIFF
--- a/static/base.less
+++ b/static/base.less
@@ -55,3 +55,8 @@ h6 {
   line-height: 1.4;
   .border-bottom;
 }
+.tag {
+  font-size: 50%;
+  font-weight: normal;
+  color: #666;
+}

--- a/static/base.less
+++ b/static/base.less
@@ -55,22 +55,3 @@ h6 {
   line-height: 1.4;
   .border-bottom;
 }
-
-// Body text
-// --------------------------------------------------
-
-p {
-  margin-top: 0;
-  margin-bottom: @gutter;
-}
-
-small {
-  font-size: 90%;
-}
-article {
-  code {
-    .border-radius;
-    background: @code-color;
-    font-size: .9em;
-  }
-}

--- a/static/canjs.less
+++ b/static/canjs.less
@@ -10,4 +10,5 @@
 // Components
 @import "header.less";
 @import "sidebar.less";
+@import "content.less";
 @import "footer.less";

--- a/static/content.less
+++ b/static/content.less
@@ -1,0 +1,27 @@
+.main-container {
+  article {
+    p {
+      margin-top: 0;
+      margin-bottom: @gutter;
+      line-height: 1.6;
+    }
+    ul, ol {
+      li {
+        line-height: 1.6;
+      }
+    }
+    small {
+      font-size: 90%;
+    }
+    code {
+      .border-radius;
+      background: @code-color;
+      font-size: .9em;
+      color: #a12f2e;
+    }
+    pre code {
+      background: none;
+    }
+  } // article
+} //.main-container
+

--- a/static/content.less
+++ b/static/content.less
@@ -11,6 +11,10 @@
       
       li {
         line-height: 1.6;
+        
+        > p:first-of-type {
+          display: inline;
+        }
       }
     }
     small {
@@ -50,8 +54,6 @@
     }
     .parameters {
       padding: 0 @gutter;
-      border-left: 4px solid @border-color;
-      margin-left: @gutter;
       
       .parameters-title {
         border: none;
@@ -67,6 +69,7 @@
           list-style-type: none;
           counter-increment: item;
           margin-left: -@gutter*2;
+          margin-bottom: @gutter;
           
           &:before {
             display: inline-block;
@@ -76,11 +79,8 @@
             text-align: right;
             content: counter(item) ".";
           }
-          
-          > p:first-of-type {
-            border-top: 1px solid @border-color;
-            margin-top: 4px;
-            padding-top: 4px;
+          &:last-child {
+            margin-bottom: 0;
           }
         }
       }

--- a/static/content.less
+++ b/static/content.less
@@ -6,6 +6,9 @@
       line-height: 1.6;
     }
     ul, ol {
+      margin-bottom: @gutter;
+      list-style-type: disc;
+      
       li {
         line-height: 1.6;
       }
@@ -15,12 +18,70 @@
     }
     code {
       .border-radius;
-      background: @code-color;
+      background: @border-color;
       font-size: .9em;
-      color: #a12f2e;
+      color: @code-color;
     }
     pre code {
       background: none;
+    }
+    
+    .signature {
+      padding-left: @gutter;
+      padding-right: @gutter;
+      margin-bottom: @gutter;
+      border: 1px solid @border-color;
+      
+      .signature-title {
+        background: #eee;
+        margin-top: 0;
+        margin-left: -@gutter;
+        margin-right: -@gutter;
+        padding-left: @gutter/2;
+        
+        code {
+          font-weight: bold;
+          .font-smoothing;
+          color: darken(@code-color,10%);
+        }
+      }
+    }
+    .parameters {
+      padding: 0 @gutter;
+      border-left: 4px solid @border-color;
+      margin-left: @gutter;
+      
+      .parameters-title {
+        border: none;
+      }
+      > ol {
+        margin: 0 0 1.5em;
+        padding: 0;
+        counter-reset: item;
+        
+        > li {
+          margin: 0;
+          padding: 0 0 0 2em;
+          list-style-type: none;
+          counter-increment: item;
+          margin-left: -@gutter*2;
+          
+          &:before {
+            display: inline-block;
+            width: 1em;
+            padding-right: 0.5em;
+            font-weight: bold;
+            text-align: right;
+            content: counter(item) ".";
+          }
+          
+          > p:first-of-type {
+            border-top: 1px solid @border-color;
+            margin-top: 4px;
+            padding-top: 4px;
+          }
+        }
+      }
     }
   } // article
 } //.main-container

--- a/static/content.less
+++ b/static/content.less
@@ -33,7 +33,7 @@
       border: 1px solid @border-color;
       
       .signature-title {
-        background: #eee;
+        background: lighten(@border-color, 5%);
         margin-top: 0;
         margin-left: -@gutter;
         margin-right: -@gutter;
@@ -43,6 +43,8 @@
           font-weight: bold;
           .font-smoothing;
           color: darken(@code-color,10%);
+          padding: 0;
+          background: none;
         }
       }
     }

--- a/static/variables.less
+++ b/static/variables.less
@@ -1,7 +1,7 @@
 @link-color: #4078c0;
 @border-color: #eee;
 @logo-color: green;
-@code-color: @border-color;
+@code-color: #a12f2e;
 
 @breakpoint: 700px;
 @gutter: 15px;

--- a/templates/signature.mustache
+++ b/templates/signature.mustache
@@ -1,23 +1,31 @@
-<h2><code>{{{makeSignature code}}}</code></h2>
-{{{makeHtml (makeLinks description)}}}
-
-{{#if params}}
-<ol>
-{{#params}}
-<li> {{{makeParams}}}: {{{makeHtml (makeLinks description)}}} </li>
-{{/params}}
-</ol>
-{{/if}}
-{{#returns}}
-<ul>
-    <li><b>returns</b> {{{makeReturn}}}: {{{makeHtml (makeLinks description)}}} </li>
-</ul>
-{{/returns}}
-{{#if options.length}}
-<ul>
-{{#options}}
-  <li><b>{{name}}</b> {{#if types}}<code>{{{makeTypesString types}}}</code>{{/if}}:
-  {{{makeHtml (makeLinks description)}}}</li>
-{{/options}}
-</ul>
-{{/if}}
+<div class="signature">
+  <h2><code>{{{makeSignature code}}}</code></h2>
+  {{{makeHtml (makeLinks description)}}}
+  
+  {{#if params}}
+    <h3>Parameters</h3>
+      <ol class="parameters">
+        {{#params}}
+          <li>{{{makeParams}}}: {{{makeHtml (makeLinks description)}}}</li>
+        {{/params}}
+      </ol>
+  {{/if}}
+  
+  {{#returns}}
+  <ul>
+      <li><b>returns</b> {{{makeReturn}}}: {{{makeHtml (makeLinks description)}}} </li>
+  </ul>
+  {{/returns}}
+  
+  {{#if options.length}}
+  <h3>Options</h3>
+    <ul>
+    {{#options}}
+      <li>
+        <b>{{name}}</b> {{#if types}}<code>{{{makeTypesString types}}}</code>{{/if}}:
+        {{{makeHtml (makeLinks description)}}}
+      </li>
+    {{/options}}
+    </ul>
+  {{/if}}
+</div>

--- a/templates/signature.mustache
+++ b/templates/signature.mustache
@@ -1,14 +1,16 @@
 <div class="signature">
-  <h2><code>{{{makeSignature code}}}</code></h2>
+  <h2 class="signature-title"><code>{{{makeSignature code}}}</code></h2>
   {{{makeHtml (makeLinks description)}}}
   
   {{#if params}}
-    <h3>Parameters</h3>
-      <ol class="parameters">
+  <div class="parameters">
+    <h3 class="parameters-title">Parameters</h3>
+      <ol>
         {{#params}}
           <li>{{{makeParams}}}: {{{makeHtml (makeLinks description)}}}</li>
         {{/params}}
       </ol>
+  </div>
   {{/if}}
   
   {{#returns}}
@@ -18,6 +20,7 @@
   {{/returns}}
   
   {{#if options.length}}
+  <div class="options">
   <h3>Options</h3>
     <ul>
     {{#options}}
@@ -27,5 +30,6 @@
       </li>
     {{/options}}
     </ul>
+  </div>
   {{/if}}
 </div>


### PR DESCRIPTION
This PR has some better spacing for paragraphs and uls/ols in the content overall. 

BUT it also includes a proposed design for both signatures and parameters. Note, I haven't done options or returns yet... @justinbmeyer please have a look and let me know what you think. I wasn't able to find a way to avoid having at least the Signatures in a bordered-container. 

Oh! Also, I made `<code>` with red-colored text and I liked it. But it's a simple change, if you don't think it works. It seems like just the right amount of stand-out-ness. 

![screen shot 2016-07-01 at 1 52 05 pm](https://cloud.githubusercontent.com/assets/326843/16531744/7fb2ccdc-3f93-11e6-9500-28f95c129ef7.png)
