### PR TITLE
Slide out menu on mobile

### DIFF
--- a/static/footer.less
+++ b/static/footer.less
@@ -1,5 +1,5 @@
 footer {
-  padding: @gutter*2;
+  padding-top: @gutter*2;
   margin-top: @gutter*2;
   border-top: 1px solid @border-color;
 }

--- a/static/header.less
+++ b/static/header.less
@@ -168,3 +168,12 @@ header {
   }
 }
 
+@media screen and (min-width: @breakpoint) {
+  header {
+    .navbar {
+      .brand {
+        margin-left: 0;
+      }
+    }
+  } 
+}

--- a/static/header.less
+++ b/static/header.less
@@ -2,6 +2,8 @@
 
 header {
   font-family: 'Lato', sans-serif;
+  margin-left: -@gutter;
+  margin-right: -@gutter;
   
   .navbar {
     .flex;
@@ -66,6 +68,7 @@ header {
       background-image: url(img/canjs_logo.svg);
       background-size: cover;
       margin-right: @gutter*2;
+      margin-left: 65px;
     }
   }
   .dropdown {
@@ -116,6 +119,7 @@ header {
   
   .bitovi-menu {
       .flex;
+      padding: 0;
       margin: 0;
       margin-left: auto;
       align-items: center;

--- a/static/layout.less
+++ b/static/layout.less
@@ -1,22 +1,48 @@
+html, body {
+  height:100%;
+}
+
+body {
+  overflow-x: hidden;
+}
+
 .main-container {
-  .flex;
-  flex-direction: column;
+  //.flex;
+  //flex-direction: column;
+  overflow-x: hidden;
   margin: 0 @gutter*2;
   padding-top: @gutter;
+  position: relative;
+  padding: 0;
+  margin: 0;
+  margin-top: -@gutter;
+  height: 100%;
 
   > article > section > h1 {
     margin-top: 0;
+  }
+  
+  .site-wrap {
+    min-width: 100%;
+    min-height: 100%;
+    background-color: #fff;
+    position: relative;
+    top: 0;
+    bottom: 100%;
+    left: 0;
+    z-index: 1;
+    padding: @gutter;
   }
 }
 
 @media screen and (min-width: @breakpoint) {
   
   .main-container {
-    flex-direction: row;
-    flex-wrap: nowrap;
+    //flex-direction: row;
+    //flex-wrap: nowrap;
     
     article {
-      flex: 1;
+      //flex: 1;
     }
     .sidebar {
       margin-right: @gutter*2;

--- a/static/layout.less
+++ b/static/layout.less
@@ -7,8 +7,6 @@ body {
 }
 
 .main-container {
-  //.flex;
-  //flex-direction: column;
   overflow-x: hidden;
   margin: 0 @gutter*2;
   padding-top: @gutter;
@@ -36,16 +34,10 @@ body {
 }
 
 @media screen and (min-width: @breakpoint) {
-  
-  .main-container {
-    //flex-direction: row;
-    //flex-wrap: nowrap;
-    
+    .site-wrap {
+      background: none;
+    }
     article {
-      //flex: 1;
+      margin-left: @sidebar-width;
     }
-    .sidebar {
-      margin-right: @gutter*2;
-    }
-  }
 }

--- a/static/sidebar.less
+++ b/static/sidebar.less
@@ -1,5 +1,5 @@
 .sidebar {
-  width: 200px; 
+  width: @sidebar-width; 
   padding-left: @gutter;
   height: 100%;
   position: fixed;
@@ -11,7 +11,6 @@
   overflow-x: hidden;
   overflow-y:scroll;
   background: #fff;
-
   
   ul {
     padding-left: @gutter/1.5;
@@ -92,7 +91,7 @@
 
 // -- Mobile Menu Menu
 .nav-trigger {
-  position: absolute;
+  position: fixed;
   clip: rect(0, 0, 0, 0);
 }
 label[for="nav-trigger"] {
@@ -114,9 +113,28 @@ label[for="nav-trigger"] {
     left: 215px;
 }
 .nav-trigger:checked ~ .site-wrap {
-    left: 200px;
+    left: @sidebar-width;
     .box-shadow (0, 0, 10px);
 }
 .nav-trigger + label, .site-wrap {
     transition: left 0.2s;
+}
+
+@media screen and (min-width: @breakpoint) {
+    .sidebar {
+      margin-right: @gutter*2;
+      position: relative;
+      overflow: visible;
+      width: auto;
+      min-width: @sidebar-width;
+      height: auto;
+      position: absolute;
+      top: 100px;
+      left: 0;
+      z-index: 3;
+      width: @sidebar-width;
+    }
+  .nav-trigger, label[for="nav-trigger"] {
+    display: none;
+  } 
 }

--- a/static/sidebar.less
+++ b/static/sidebar.less
@@ -1,5 +1,17 @@
 .sidebar {
-  min-width: 200px; 
+  width: 200px; 
+  padding-left: @gutter;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 0;
+  overflow-x: hidden;
+  overflow-y:scroll;
+  background: #fff;
+
   
   ul {
     padding-left: @gutter/1.5;
@@ -76,4 +88,35 @@
         }
     }
   }
+}
+
+// -- Mobile Menu Menu
+.nav-trigger {
+  position: absolute;
+  clip: rect(0, 0, 0, 0);
+}
+label[for="nav-trigger"] {
+  position: fixed;
+  top: 7px;
+  left: 10px;
+  z-index: 2;
+  font-family: Lato, sans-serif;
+  border: 1px solid @border-color;
+  padding: 10px;
+  background: #fff;
+  text-transform: uppercase;
+  font-size: 12px;
+  cursor: pointer;
+  font-weight: 700;
+  .border-radius;
+}
+.nav-trigger:checked + label {
+    left: 215px;
+}
+.nav-trigger:checked ~ .site-wrap {
+    left: 200px;
+    .box-shadow (0, 0, 10px);
+}
+.nav-trigger + label, .site-wrap {
+    transition: left 0.2s;
 }

--- a/static/variables.less
+++ b/static/variables.less
@@ -3,5 +3,6 @@
 @logo-color: green;
 @code-color: @border-color;
 
-@breakpoint: 700px;
 @gutter: 15px;
+@breakpoint: 700px;
+@sidebar-width: 200px;

--- a/templates/content.mustache
+++ b/templates/content.mustache
@@ -2,7 +2,9 @@
 {{#unless hideSidebar}}
 	{{> sidebar.mustache}}
 {{/unless}}
-<article>
+<article class="site-wrap">
+<header>{{> header.mustache}}</header>
+
 	{{#unless hideTitle}}
 		{{> title.mustache}}
 	{{/unless}}
@@ -31,5 +33,8 @@
 			{{> body.mustache}}
 		{{/if}}
 	{{/unless}}
+	
+	<footer>{{> footer.mustache}}</footer>
 </article>
 </div>
+

--- a/templates/content.mustache
+++ b/templates/content.mustache
@@ -1,10 +1,11 @@
-<div class='main-container'>
+<div class="main-container">
 {{#unless hideSidebar}}
 	{{> sidebar.mustache}}
 {{/unless}}
-<article class="site-wrap">
+<div class="site-wrap">
 <header>{{> header.mustache}}</header>
 
+<article>
 	{{#unless hideTitle}}
 		{{> title.mustache}}
 	{{/unless}}
@@ -35,6 +36,10 @@
 	{{/unless}}
 	
 	<footer>{{> footer.mustache}}</footer>
+	
 </article>
+
+	
+</div>
 </div>
 

--- a/templates/layout.mustache
+++ b/templates/layout.mustache
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+{{{generatedWarning}}}
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>{{getTitle}}</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+	{{^devBuild}}
+	<link rel="stylesheet" type="text/css" href="{{pathToDest}}/static/bundles/bit-docs-site/static.css">
+	{{/devBuild}}
+</head>
+
+<body>
+	{{{content}}}
+
+	<script type="text/javascript">
+		var docObject = {{{docObjectString}}};
+	</script>
+
+	{{#if devBuild}}
+		<script type='text/javascript'
+			data-main="bit-docs-site/static"
+			src="./static/node_modules/steal/steal.js"></script>
+	{{else}}
+		<script>
+		  steal = {
+		    instantiated: {
+		      "bundles/bit-docs-site/static.css!$css" : null
+		    }
+		  }
+		</script>
+		<script type='text/javascript'
+				data-main="bit-docs-site/static"
+				src="{{pathToDest}}/static/node_modules/steal/steal.production.js"></script>
+	{{/if}}
+</body>
+
+</html>

--- a/templates/sidebar.mustache
+++ b/templates/sidebar.mustache
@@ -3,3 +3,6 @@
         {{>menu.mustache}}
     {{/with}}
 </nav>
+
+<input type="checkbox" id="nav-trigger" class="nav-trigger" />
+<label for="nav-trigger">Menu</label>


### PR DESCRIPTION
For mobile, I moved the menu to slide out from off canvas. It works nicely: 
![slideout-rwd](https://cloud.githubusercontent.com/assets/326843/16534974/5df82e96-3fa9-11e6-97bf-7d66b43b09d0.gif)
![slideout](https://cloud.githubusercontent.com/assets/326843/16534975/5e11fb6e-3fa9-11e6-8cde-5ab8486c91a9.gif)

The downside is that the way I'm doing it (atm) requires the sidebar to be a fixed width (200px) - which is fine for most menu items, but for the longer ones it wraps the text. I think I can find a way around it and use a flexible column like we had before. I just need to play with it some more. 

![screen shot 2016-07-01 at 4 32 38 pm](https://cloud.githubusercontent.com/assets/326843/16535002/9f83a7be-3fa9-11e6-916b-64fbc3a261ef.png)
