### PR TITLE
API updates

### DIFF
--- a/static/base.less
+++ b/static/base.less
@@ -55,8 +55,3 @@ h6 {
   line-height: 1.4;
   .border-bottom;
 }
-h1.tag {
-  font-size: 50%;
-  font-weight: normal;
-  color: #666;
-}

--- a/static/content.less
+++ b/static/content.less
@@ -89,5 +89,17 @@
         }
       }
     }
+    .deprecated.warning {
+      padding: @gutter;
+      border: 1px solid @warning-color;
+      margin-bottom: @gutter;
+      padding-bottom: 0;
+      
+      h3 {
+        margin: 0;
+        margin-bottom: @gutter;
+        color: @warning-color;
+      }
+    }
   } // article
 } //.main-container

--- a/static/content.less
+++ b/static/content.less
@@ -29,7 +29,13 @@
     pre code {
       background: none;
     }
-    
+    .title {
+      .type {
+        font-weight: normal;
+        color: #666;
+        font-size: 50%;
+      }
+    }
     .signature {
       padding-left: @gutter;
       padding-right: @gutter;
@@ -52,12 +58,10 @@
         }
       }
     }
-    .parameters {
+    .parameters, .options, .returns {
       padding: 0 @gutter;
-      
-      .parameters-title {
-        border: none;
-      }
+    }
+    .parameters {
       > ol {
         margin: 0 0 1.5em;
         padding: 0;

--- a/static/content.less
+++ b/static/content.less
@@ -103,3 +103,63 @@
     }
   } // article
 } //.main-container
+
+.on-this-page {
+  padding: 0;
+  border: 1px solid darken(@border-color, 10%);
+  background: #fff;
+  font-size: 1.5em;
+  font-weight: 700;
+
+  li {  
+    list-style: none;
+    list-style-type: none;
+  
+    a {
+      display: block;
+      padding: 5px 10px;
+      border-top: 1px solid transparent;
+      border-bottom: 1px solid transparent;
+      
+      &:hover {
+        border-top: 1px solid @border-color;
+        border-bottom: 1px solid @border-color;
+      }
+    }
+    
+    &:first-child a, &:first-child a:hover {
+      border-top: none;
+    }
+    &:last-child a, &:last-child a:hover {
+      border-bottom: none;
+    }
+  }
+  h3 {
+    margin: 0;
+    padding: 5px 10px;
+    line-height: 1.5;
+  }
+  &.fixed {
+    position: fixed;
+    width: 100%;
+    top: 0;
+    margin: 0;
+    margin-top: -1px;
+    left: auto;
+    
+    li {
+      display: none;
+      
+      &.active {
+        display: block;
+      }
+    }
+    
+    &.open {
+      li {
+        display: block;
+      }
+    }
+
+  }
+} //.on-this-page

--- a/static/content.less
+++ b/static/content.less
@@ -60,6 +60,10 @@
     }
     .parameters, .options, .returns {
       padding: 0 @gutter;
+      
+      .parameters-title, .options-title, .returns-title {
+        border: none;
+      }
     }
     .parameters {
       > ol {

--- a/static/variables.less
+++ b/static/variables.less
@@ -2,6 +2,7 @@
 @border-color: #eee;
 @logo-color: green;
 @code-color: black;
+@warning-color: #d14;
 @gray: #999;
 
 @gutter: 15px;

--- a/templates/content.mustache
+++ b/templates/content.mustache
@@ -9,6 +9,15 @@
     		{{> title.mustache}}
     	{{/unless}}
 
+      <!--
+      <ul class="on-this-page fixed open">
+        <li><a href="#">Monkeys</a></li>
+        <li class="active"><a href="#">Fish</a></li>
+        <li><a href="#">Cats</a></li>
+        <li><a href="#">Dogs</a></li>
+      </ul>
+      -->
+      
         {{#if deprecated.length}}
 			<section class='warnings'>
 				{{#deprecated}}

--- a/templates/signature.mustache
+++ b/templates/signature.mustache
@@ -14,14 +14,15 @@
   {{/if}}
   
   {{#returns}}
-  <ul>
-      <li><b>returns</b> {{{makeReturn}}}: {{{makeHtml (makeLinks description)}}} </li>
-  </ul>
+  <div class="returns">
+    <h3 class="returns-title">Returns</h3>
+     <p>{{{makeReturn}}}: {{{makeHtml (makeLinks description)}}}</p>
+  </div>
   {{/returns}}
   
   {{#if options.length}}
   <div class="options">
-  <h3>Options</h3>
+  <h3 class="options-title">Options</h3>
     <ul>
     {{#options}}
       <li>

--- a/templates/title.mustache
+++ b/templates/title.mustache
@@ -1,3 +1,3 @@
 <section class="title">
-	<h1>{{getTitle .}}</h1>
+	<h1>{{getTitle .}} <small class="type">page</small></h1>
 </section>

--- a/templates/title.mustache
+++ b/templates/title.mustache
@@ -1,3 +1,3 @@
 <section class="title">
-	<h1>{{getTitle .}} <small class="type">page</small></h1>
+	<h1>{{getTitle .}} <!-- <small class="type">page</small> --></h1>
 </section>


### PR DESCRIPTION
This modifies parameters and returns to have the same indentation. I did that partly by removing the indentation from parameters, but this might have a negative effect on nested parameters. I'll need to check. I opened https://github.com/canjs/bit-docs-html-canjs/issues/19 to address the returns being on 2 lines
<img width="348" alt="screen shot 2016-07-12 at 1 35 42 pm" src="https://cloud.githubusercontent.com/assets/326843/16784245/75b47696-484d-11e6-82ea-927c5885d361.png">


Also adds support for "types" like page, stylesheet, etc.. next to the title which is needed for https://github.com/canjs/bit-docs-html-canjs/issues/11
<img width="380" alt="screen shot 2016-07-12 at 1 35 47 pm" src="https://cloud.githubusercontent.com/assets/326843/16784259/8855c660-484d-11e6-9b97-4cb1888c5e33.png">


Also adds placeholder styles for the depreciated warning for https://github.com/canjs/bit-docs-html-canjs/issues/17
![screen shot 2016-07-12 at 2 41 25 pm](https://cloud.githubusercontent.com/assets/326843/16784270/90da64da-484d-11e6-9842-99651d3a5c2c.png)


Finally, I started on the "On this page" menu at the top but I think I'll need help making the JS work before I do much more of the CSS. Maybe @matthewp can help me with that part? This is https://github.com/canjs/bit-docs-html-canjs/issues/12

