### PR TITLE
fixes video styles by adding light gray border and width

### DIFF
--- a/static/content.less
+++ b/static/content.less
@@ -152,7 +152,13 @@ ul.title-social{
   }
 }
 video{
-  background: @border-color;
+  background: @light-color;
+  border: 1px solid @dark-border-color;
+  margin: @gutter*2 0;
+  width: 100%;
+  @media screen and (min-width: @breakpoint-xl) {
+    width: 1000px;
+  }
 }
 blockquote{
   display: block;

--- a/static/variables.less
+++ b/static/variables.less
@@ -12,4 +12,5 @@
 
 @gutter: 15px;
 @breakpoint: 700px;
+@breakpoint-xl: 1300px;
 @sidebar-width: 200px;


### PR DESCRIPTION
Added medium gray border and light gray background.

Width of video is set to 100% until it reaches 1000px, then it stays at 1000px.

<img width="1054" alt="screen shot 2016-09-26 at 12 35 08 pm" src="https://cloud.githubusercontent.com/assets/5323173/18843200/bfc002fe-83e5-11e6-8424-d0b1276e8fb8.png">
<img width="1467" alt="screen shot 2016-09-26 at 12 35 16 pm" src="https://cloud.githubusercontent.com/assets/5323173/18843201/bfcee904-83e5-11e6-9900-c55be83a2019.png">
