### PR TITLE
Added styles back in that were lost in merge

### DIFF
--- a/static/content.less
+++ b/static/content.less
@@ -57,8 +57,7 @@ article {
   .signature {
     padding: @gutter*2;
     margin: @gutter*2;
-    border-left: 15px solid @link-color;
-    border-right: 2px solid @link-color;
+    border: 1px solid @link-color;
     background: lighten(@link-color, 48%);
     word-wrap: break-word;
     h3{

--- a/static/demo.less
+++ b/static/demo.less
@@ -22,7 +22,7 @@
     }
     li.tab .active {
       font-weight: bold;
-      border: 1px solid #eee;
+      border: 1px solid @dark-border-color;
       border-bottom: solid 2px white;
       border-radius: 4px 4px 0 0;
       color: @gray;

--- a/templates/footer.mustache
+++ b/templates/footer.mustache
@@ -1,1 +1,1 @@
-<p>CanJS is part of <a href="http://donejs.com">DoneJS</a>. Created and maintained by the open source team at <a href="http://bitovi.com">Bitovi</a>. <strong>Currently {{package.version}}.</strong></p>
+<p>CanJS is part of <a href="http://donejs.com" target="_blank">DoneJS</a>. Created and maintained by the core <a href="https://donejs.com/About.html#section=section_Team" target="_blank">DoneJS team</a> and <a href="http://bitovi.com" target="_blank">Bitovi</a>. <strong>Currently {{package.version}}.</strong></p>


### PR DESCRIPTION
# Signature
<img width="1356" alt="screen shot 2016-10-07 at 10 08 25 am" src="https://cloud.githubusercontent.com/assets/5323173/19192945/110db6d6-8c76-11e6-9378-59657679db6f.png">
&nbsp;
&nbsp;

# Footer
<img width="1355" alt="screen shot 2016-10-07 at 10 08 33 am" src="https://cloud.githubusercontent.com/assets/5323173/19192963/215063c2-8c76-11e6-8368-82ddaf71b6f1.png">
&nbsp;
&nbsp;

# Demo tabs
- Added variable for border color