### PR TITLE
Fix code block expansion styles

### DIFF
--- a/static/content.less
+++ b/static/content.less
@@ -53,7 +53,10 @@ article {
     display: block;
     margin: @gutter;
     word-wrap: break-word;
-	float: left;
+    &.line-highlight {
+        display: inline-block;
+        min-width: 100%;
+    }
   }
   .signature {
     padding: @gutter*2;


### PR DESCRIPTION
For #139 

I left out `width:100%` that was supposed to be included in the `float:left` fix, but that still didn't quite work correctly. A better fix is using a `min-width` with `inline-block`.