### PR TITLE
Fix getHeaders function to re-enable on this page dropdown

### DIFF
--- a/static/breadcrumb.less
+++ b/static/breadcrumb.less
@@ -1,123 +1,123 @@
-.breadcrumb{
-  display: none;
-  @media screen and (min-width: @breakpoint){
-	height: 48px;
-    display: block;
-    padding-left: @gutter*2;
-    color: white;
-    background: @code-color;
-    cursor: pointer;
-    color: lighten(@gray, 10%);
-    .breadcrumb-dropdown{
-      padding: @gutter @gutter/4;
-      &::after {
-        content: '\2329';
-        padding-bottom: 0px;
-        padding-right: @gutter/4;
-        margin-bottom: 0px;
-        display: inline-block;
-        -webkit-transform: rotate(270deg);
-        -moz-transform: rotate(270deg);
-        -o-transform: rotate(270deg);
-        -ms-transform: rotate(270deg);
-        transform: rotate(270deg);
-        font-size: 0.7em;
-        color: white;
-      }
-    }
-    li{
-      display: inline-block;
-      list-style: none;
-      color: @link-color;
-      padding-left: @gutter/4;
-      padding-right: @gutter/4;
-      a{
-        color: white;
-        font-size: 14px;
-        code{
-          background: none;
-          line-height: 14px;
-        }
-      }
-    }
-    .breadcrumb-dropdown {
-      position: relative;
-      &:hover {
-        .on-this-page {
-          display: flex;
-          li{
-            flex-grow: 1;
-            flex-basis: auto;
-          }
-        }
-      }
-    }
-  }
+.breadcrumb {
+  	display: none;
+  	@media screen and (min-width: @breakpoint) {
+		height: 48px;
+	    display: block;
+	    padding-left: @gutter*2;
+	    background: @code-color;
+	    cursor: pointer;
+	    color: lighten(@gray, 10%);
+	    .breadcrumb-dropdown {
+			display: none;
+	      	padding: @gutter @gutter/4;
+			position: relative;
+			color: lighten(@gray, 10%);
+			a {
+				padding-left: @gutter/4;
+				color: white;
+			}
+			&:hover {
+	        	.on-this-page {
+	          		display: flex;
+	          		li {
+	            		flex-grow: 1;
+	            		flex-basis: auto;
+	          		}
+	        	}
+	      	}
+      		&::after {
+		        content: '\2329';
+		        padding-bottom: 0px;
+		        padding-right: @gutter/4;
+		        margin-bottom: 0px;
+		        display: inline-block;
+		        -webkit-transform: rotate(270deg);
+		        -moz-transform: rotate(270deg);
+		        -o-transform: rotate(270deg);
+		        -ms-transform: rotate(270deg);
+		        transform: rotate(270deg);
+		        font-size: 0.7em;
+		        color: white;
+      		}
+    	}
+    	li {
+			display: inline-block;
+			list-style: none;
+			color: @link-color;
+			padding: @gutter @gutter/4;
+	      	a {
+	        	color: white;
+	        	font-size: 14px;
+	        	code {
+	          		background: none;
+	          		line-height: 14px;
+	        	}
+	      	}
+    	}
+  	}
 }
-
-
 
 .on-this-page {
-  width: 100%;
-  font-size: 14px;
-  margin-top:@gutter/2;
-  margin-bottom: @gutter !important;
-  background: #fbfbfb;
-  list-style: none;
-  line-height: 1.5em;
-  a {
-    color: @link-color !important;
-  }
-  @media screen and (min-width: @breakpoint) {
-    padding: @gutter;
-    margin: 0;
-    position: fixed;
-    box-shadow: 0 0 7px rgba(0, 0, 0, 0.1);
-    z-index: 15;
-    cursor: pointer;
-    display: none;
-    margin-top: 15px;
-    width: auto;
-    flex-direction: column;
-    flex-wrap: nowrap;
-    li{
-      padding: 0px;
-      margin: 0px;
-      code{
-        background: none;
-        font-weight: 600;
-        padding: 0;
-      }
-      a{
-        width: auto;
-        padding: 0px;
-        margin: 0px;
-      }
-    }
-    li:hover{
-      text-decoration: underline;
-    }
-    li .current{
-      text-decoration: underline;
-      font-weight: bold;
-    }
-    &::before {
-      content: '';
-      width:10px;
-      height: 10px;
-      background: #fbfbfb;
-      position: absolute;
-      top:-4px;
-      left: @gutter;
-      -webkit-transform: rotate(-45deg);
-      -moz-transform: rotate(-45deg);
-      -o-transform: rotate(-45deg);
-      -ms-transform: rotate(-45deg);
-      transform: rotate(-45deg);
-      z-index: 16;
-    }
-  }
+  	width: 100%;
+  	font-size: 14px;
+  	margin-top:@gutter/2;
+  	margin-bottom: @gutter !important;
+  	background: #fbfbfb;
+  	list-style: none;
+  	line-height: 1.5em;
+  	a {
+    	color: @link-color !important;
+  	}
+  	@media screen and (min-width: @breakpoint) {
+    	padding: @gutter;
+    	margin: 0;
+    	position: fixed;
+    	box-shadow: 0 0 7px rgba(0, 0, 0, 0.1);
+    	z-index: 15;
+    	cursor: pointer;
+    	display: none;
+    	margin-top: 15px;
+    	width: auto;
+    	flex-direction: column;
+    	flex-wrap: nowrap;
+    	li {
+      		padding: 0px;
+      		margin: 0px;
+      		code {
+        		background: none;
+        		font-weight: 600;
+        		padding: 0;
+      		}
+	      	a {
+	        	width: auto;
+	        	padding: 0px;
+	        	margin: 0px;
+	      	}
+    	}
+    	li:hover {
+      		text-decoration: underline;
+    	}
+    	li .current {
+      		text-decoration: underline;
+      		font-weight: bold;
+    	}
+    	&::before {
+      		content: '';
+      		width:10px;
+      		height: 10px;
+      		background: #fbfbfb;
+      		position: absolute;
+      		top:-4px;
+      		left: @gutter;
+      		-webkit-transform: rotate(-45deg);
+      		-moz-transform: rotate(-45deg);
+      		-o-transform: rotate(-45deg);
+      		-ms-transform: rotate(-45deg);
+      		transform: rotate(-45deg);
+      		z-index: 16;
+    	}
+  	}
 }
 .on-this-page:empty{
-  visibility: hidden;
+  	visibility: hidden;
 }

--- a/static/canjs.js
+++ b/static/canjs.js
@@ -159,16 +159,17 @@ function navigate(href) {
 	});
 }
 
-function getHeaders() {
-	var	outline = window.docObject && parseInt(window.docObject.outline),
-		outlineLevel = !isNaN(outline) ? outline : 1,
-		headerArr = [];
-	for (var i = 1; i <= outlineLevel; i++) {
-		headerArr.push('h' + (i + 1));
+function getHeaders(useOutline) {
+	var headerArr = [],
+		headerDepth = 1;
+
+	if (useOutline) {
+		var	outline = window.docObject && parseInt(window.docObject.outline);
+		headerDepth = !isNaN(outline) ? outline : 1;
 	}
 
-	if (headerArr.length < 2) {
-		return;
+	for (var i = 1; i <= headerDepth; i++) {
+		headerArr.push('h' + (i + 1));
 	}
 
 	return $(headerArr.join(', ')).each(function(index, header) {
@@ -202,6 +203,7 @@ function setOnThisPageContent() {
 	if ($h2.length < 2) {
 		return;
 	}
+	$('.breadcrumb-dropdown').css('display', 'inline-block');
 	// add items to on-this-page dropdown
 	$.each($h2, function(index, header) {
 		$onThisPage.append("<a href=#"+header.id+"><li>"+$(header).html()+"</li></a>");
@@ -298,15 +300,17 @@ function toggleNav() {
 }
 
 function buildTOC() {
-	if (!$headers.length) {
+	var $tocHeaders = getHeaders(true);
+
+	if (!$tocHeaders.length || $tocHeaders.length < 2) {
 		return;
 	}
 
 	var level = 0,
-		baseLevel = $headers[0].nodeName.substr(1),
+		baseLevel = $tocHeaders[0].nodeName.substr(1),
 		toc = "<ol>";
 
-	$headers.each(function(index, element) {
+	$tocHeaders.each(function(index, element) {
 		var $el = $(element);
 		var title = $el.text().replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
 		var link = '#' + generateId($el[0]);

--- a/templates/breadcrumb.mustache
+++ b/templates/breadcrumb.mustache
@@ -3,9 +3,9 @@
 		<li><a href="{{urlTo name}}">{{getShortTitle .}}</a></li> /
 	{{/each}}
 	{{#with (getCurrent)}}
-	<li><a href="{{urlTo name}}">{{getShortTitle .}}</a></li> /
+	<li><a href="{{urlTo name}}">{{getShortTitle .}}</a></li>
 	{{/with}}
-	<li class="breadcrumb-dropdown"><a> On this page</a>
+	<li class="breadcrumb-dropdown">/ <a> On this page</a>
 	  <ul class="on-this-page"></ul>
 	</li>
 </div>


### PR DESCRIPTION
For #173

A bug was introduced to the `getHeaders` function when adding the Table of Contents hide for any article with less than 2 headers. The On This Page dropdown only works with `h2` elements. Only the TOC should use the outline level.

This also adds hiding to the On This Page breadcrumb when empty. Previously only the dropdown was hidden.