### PR TITLE
Use box-shadow mixin

### DIFF
--- a/static/breadcrumb.less
+++ b/static/breadcrumb.less
@@ -59,7 +59,7 @@
   	font-size: 14px;
   	margin-top:@gutter/2;
   	margin-bottom: @gutter !important;
-  	background: #fbfbfb;
+  	background: #fff;
   	list-style: none;
   	line-height: 1.5em;
   	a {
@@ -69,7 +69,7 @@
     	padding: @gutter;
     	margin: 0;
     	position: fixed;
-    	box-shadow: 0 0 7px rgba(0, 0, 0, 0.1);
+    	.box-shadow;
     	z-index: 15;
     	cursor: pointer;
     	display: none;
@@ -102,7 +102,7 @@
       		content: '';
       		width:10px;
       		height: 10px;
-      		background: #fbfbfb;
+      		background: #fff;
       		position: absolute;
       		top:-4px;
       		left: @gutter;


### PR DESCRIPTION
This uses the box-shadow mixing to make the On this Page menu stand out more. I'm going to say closes #87 because I want to move the other part of 87 into a new issue. 

![screen shot 2016-11-18 at 2 59 59 pm](https://cloud.githubusercontent.com/assets/326843/20446568/ec1dd810-ad9f-11e6-9142-fa17b3d94e70.png)
