### PR TITLE
Link margin

### DIFF
--- a/static/module-list.less
+++ b/static/module-list.less
@@ -35,6 +35,9 @@
         padding-top: 1px;
         padding-bottom: 1px;
       }
+      > a {
+        margin: 0 5px;
+      }
       iframe {
         top: 6px;
         position: relative;

--- a/static/module-list.less
+++ b/static/module-list.less
@@ -35,8 +35,8 @@
         padding-top: 1px;
         padding-bottom: 1px;
       }
-      > a {
-        margin: 0 5px;
+      > a:before {
+        content: "\00a0";
       }
       iframe {
         top: 6px;


### PR DESCRIPTION
fixes #170 but feels very much like a small hack. I have no idea why this link positions itself like this. Wrapping the whole thing inside a `<p>` also fixes it, but we can't control that since the markdown generator is what creates this HTML. Oh well. 
![screen shot 2016-11-18 at 3 29 31 pm](https://cloud.githubusercontent.com/assets/326843/20447358/ff0170fa-ada3-11e6-8707-9f29444eef43.png)
