### PR TITLE
Version padding

### DIFF
--- a/static/header.less
+++ b/static/header.less
@@ -80,7 +80,7 @@
             display: inline-block;
             vertical-align: top;
             height: 100%;
-            padding-top: 9px;
+            padding-top: 7px;
             font-size: 12px;
             cursor: pointer;
             .version-number::after {


### PR DESCRIPTION
This fixes #191 but tbh it shouldn't be positioned using padding like that. And imo the logo is too small. I think this area could use a small CSS re-factor when there's time. 

![screen shot 2016-11-18 at 3 55 56 pm](https://cloud.githubusercontent.com/assets/326843/20448027/827af23c-ada7-11e6-9ba8-4079fffe7912.png)
