### PR TITLE
Don’t use pushState if a modifier key is being held down

### DIFF
--- a/static/canjs.js
+++ b/static/canjs.js
@@ -23,7 +23,8 @@ var $articleContainer,
 
 	// Override link behavior
 	$(document.body).on("click", "a", function(ev) {
-		if (this.hostname === window.location.hostname) {
+		var noModifierKeys = !ev.altKey && !ev.ctrlKey && !ev.metaKey && !ev.shiftKey;
+		if (noModifierKeys && this.hostname === window.location.hostname) {
 			ev.preventDefault();
 			var href = this.href;
 			window.history.pushState(null, null, href);


### PR DESCRIPTION
When the user holds down `alt`, `ctrl`, `shift`, or another `meta` key, we won’t use `pushState` to handle the clicked link.

Demo of holding command on macOS:
![fixed](https://cloud.githubusercontent.com/assets/10070176/21113119/2d9659dc-c05d-11e6-91fe-0bf7428e8f22.gif)

Fixes #203