### PR TITLE
Fix for broken source links

### DIFF
--- a/docMap.json
+++ b/docMap.json
@@ -15120,7 +15120,7 @@
         "params": []
       }
     ],
-    "parent": "can-core",
+    "parent": "can-define",
     "alias": "can.DefineList",
     "inherits": "can.Construct",
     "signatures": [
@@ -17362,7 +17362,7 @@
       }
     ],
     "name": "can-event/async/async",
-    "parent": "can-infrastructure",
+    "parent": "can-event",
     "signatures": [
       {
         "code": "Object",
@@ -17807,7 +17807,7 @@
       }
     ],
     "name": "can-event/batch/batch",
-    "parent": "can-infrastructure",
+    "parent": "can-event",
     "signatures": [
       {
         "code": "Object",
@@ -37928,7 +37928,7 @@
       }
     ],
     "name": "can-define/map/map",
-    "parent": "can-core",
+    "parent": "can-define",
     "alias": "can.DefineMap",
     "inherits": "can.Construct",
     "signatures": [
@@ -40299,7 +40299,7 @@
       }
     ],
     "name": "can-stache/helpers/route",
-    "parent": "can-core"
+    "parent": "can-stache"
   },
   "can-stache.helpers.routeCurrent": {
     "src": {


### PR DESCRIPTION
This is one way of fixing canjs/canjs#3060 and #204  while using the original method of retrieving a doc's source code link. However, it changes website's layout of modules like can-define/list/list, can-define/map/map, can-event/async/async, etc... It now puts them under what I think is their "real parent". Here is an example:

<img width="1020" alt="screen shot 2017-03-07 at 8 54 34 pm" src="https://cloud.githubusercontent.com/assets/8172613/23690659/4f6f654a-0378-11e7-8ea5-1ca1bd71d2a8.png">

However, if this is not a new look that we like, I can fix this another way by simply adding a new property to the objects associated to modules like can-define/list/list in docMap.json.