### PR TITLE
Fixed source link herlper

### DIFF
--- a/templates/helpers.js
+++ b/templates/helpers.js
@@ -240,7 +240,6 @@ module.exports = function(docMap, options, getCurrent, helpers, OtherHandlebars)
                 return false;
             }
             var name = packageObject.name,
-                version = 'v' + packageObject.package.version,
                 srcPath = current.src.path.replace('node_modules/' + name + '/', ''),
                 line = current.src.line ? '#L' + (current.src.line + 1) : '';
             return '//github.com/canjs/' + name + '/edit/master/' + srcPath + line;


### PR DESCRIPTION
Fixes bug that crashes `bit-docs` when pointing parent tag at something with no package.json.
```
/Users/austin/bitovi/canjs/node_modules/bit-docs/lib/configure/node_modules/q/q.js:155
                throw e;
                ^

TypeError: Cannot read property 'version' of undefined
    at Object.sourceLink (/Users/austin/bitovi/canjs/node_modules/bit-docs/lib/configure/node_modules/bit-docs-generate-html/site/templates/a57f5957978cb5171aef5ac6ec87cd7d/helpers.js:243:54)
    at program6 (eval at createFunctionContext (/Users/austin/bitovi/canjs/node_modules/bit-docs/lib/configure/node_modules/handlebars/dist/cjs/handlebars/compiler/javascript-compiler.js:189:23), <anonymous>:53:118)
    at Object.prog [as fn] (/Users/austin/bitovi/canjs/node_modules/bit-docs/lib/configure/node_modules/handlebars/dist/cjs/handlebars/runtime.js:118:12)
    at Object.<anonymous> (/Users/austin/bitovi/canjs/node_modules/bit-docs/lib/configure/node_modules/handlebars/dist/cjs/handlebars/base.js:143:49)
    at Object.eval (eval at createFunctionContext (/Users/austin/bitovi/canjs/node_modules/bit-docs/lib/configure/node_modules/handlebars/dist/cjs/handlebars/compiler/javascript-compiler.js:189:23), <anonymous>:82:28)
    at /Users/austin/bitovi/canjs/node_modules/bit-docs/lib/configure/node_modules/handlebars/dist/cjs/handlebars/runtime.js:86:31
    at /Users/austin/bitovi/canjs/node_modules/bit-docs/lib/configure/node_modules/handlebars/dist/cjs/handlebars/compiler/compiler.js:465:21
    at Object.invokePartial (/Users/austin/bitovi/canjs/node_modules/bit-docs/lib/configure/node_modules/handlebars/dist/cjs/handlebars/runtime.js:131:12)
    at Object.invokePartialWrapper [as invokePartial] (/Users/austin/bitovi/canjs/node_modules/bit-docs/lib/configure/node_modules/handlebars/dist/cjs/handlebars/runtime.js:35:39)
    at program1 (eval at createFunctionContext (/Users/austin/bitovi/canjs/node_modules/bit-docs/lib/configure/node_modules/handlebars/dist/cjs/handlebars/compiler/javascript-compiler.js:189:23), <anonymous>:11:17)
```