### PR TITLE
Move cursor pointer css from li to a

### DIFF
--- a/static/article-title.less
+++ b/static/article-title.less
@@ -50,8 +50,8 @@ ul.title-links {
 		  	display: block;
 		  	color: @link-color;
 		  	line-height: 1.7em;
-		  	cursor: pointer;
 		  	a:hover{
+		  		cursor: pointer;
 		  		text-decoration: underline;
 		  	}
 		}


### PR DESCRIPTION
Otherwise the li is block, and the cursor is a pointer where there's not actually a click target.

![cusrer-pointer](https://cloud.githubusercontent.com/assets/990216/25977726/1b6aa172-3683-11e7-8d31-ce636d21ed0b.gif)
