### PR TITLE
Fix link pathing

### DIFF
--- a/templates/helpers.js
+++ b/templates/helpers.js
@@ -234,16 +234,23 @@ module.exports = function(docMap, options, getCurrent, helpers, OtherHandlebars)
             version = version.replace(/-/g, '--');
             return 'https://img.shields.io/badge/npm%20package-'+version+'-brightgreen.svg';
         },
-        sourceLink: function(packageObject) {
-            var current = docMapInfo.getCurrent();
-            if (!current.src) {
-                return false;
-            }
-            var name = packageObject.name,
-                srcPath = current.src.path.replace('node_modules/' + name + '/', ''),
-                line = current.src.line ? '#L' + (current.src.line + 1) : '';
-            return '//github.com/canjs/' + name + '/edit/master/' + srcPath + line;
-        },
+				sourceLink: function() {
+						var current = docMapInfo.getCurrent();
+
+						if (!current.src) {
+							return false;
+						}
+
+						var nodeModulesFolderNameRegex = /^node_modules\/([\w-]+)\/.*/,
+							folderNameMatches = current.src.path.match(nodeModulesFolderNameRegex),
+							// find repoName by picking it out of the node_modules path, or we can assume this page is in the root canjs repo
+							// this assumes the npm module name matches the github repository name
+							repoName = folderNameMatches ? folderNameMatches[1] : 'canjs',
+							srcPath = current.src.path.replace('node_modules/' + repoName + '/', ''),
+							line = current.src.line ? '#L' + (current.src.line + 1) : '';
+
+						return '//github.com/canjs/' + repoName + '/edit/master/' + srcPath + line;
+				},
         customSort: function(children) {
             var ordered = [],
                 sorted = [];

--- a/templates/helpers.js
+++ b/templates/helpers.js
@@ -234,29 +234,17 @@ module.exports = function(docMap, options, getCurrent, helpers, OtherHandlebars)
             version = version.replace(/-/g, '--');
             return 'https://img.shields.io/badge/npm%20package-'+version+'-brightgreen.svg';
         },
-        repoName: function() {
-            var current = docMapInfo.getCurrent();
-
-            if (!current.src) {
-                return false;
-            }
-
+        repoName: function(path) {
             var nodeModulesFolderNameRegex = /^node_modules\/([\w-]+)\/.*/,
-              folderNameMatches = current.src.path.match(nodeModulesFolderNameRegex);
+              folderNameMatches = path.match(nodeModulesFolderNameRegex);
 
             // find repoName by picking it out of the node_modules path, or we can assume this page is in the root canjs repo
             // this assumes the npm module name matches the github repository name
             return folderNameMatches ? folderNameMatches[1] : 'canjs';
         },
-        sourceLink: function(repoName) {
-            var current = docMapInfo.getCurrent();
-
-            if (!current.src) {
-               return false;
-            }
-
-            var srcPath = current.src.path.replace('node_modules/' + repoName + '/', ''),
-              line = current.src.line ? '#L' + (current.src.line + 1) : '';
+        sourceLink: function(src, repoName) {
+            var srcPath = src.path.replace('node_modules/' + repoName + '/', ''),
+              line = src.line ? '#L' + (src.line + 1) : '';
 
             return '//github.com/canjs/' + repoName + '/edit/master/' + srcPath + line;
         },

--- a/templates/helpers.js
+++ b/templates/helpers.js
@@ -234,23 +234,32 @@ module.exports = function(docMap, options, getCurrent, helpers, OtherHandlebars)
             version = version.replace(/-/g, '--');
             return 'https://img.shields.io/badge/npm%20package-'+version+'-brightgreen.svg';
         },
-				sourceLink: function() {
-						var current = docMapInfo.getCurrent();
+        repoName: function() {
+            var current = docMapInfo.getCurrent();
 
-						if (!current.src) {
-							return false;
-						}
+            if (!current.src) {
+                return false;
+            }
 
-						var nodeModulesFolderNameRegex = /^node_modules\/([\w-]+)\/.*/,
-							folderNameMatches = current.src.path.match(nodeModulesFolderNameRegex),
-							// find repoName by picking it out of the node_modules path, or we can assume this page is in the root canjs repo
-							// this assumes the npm module name matches the github repository name
-							repoName = folderNameMatches ? folderNameMatches[1] : 'canjs',
-							srcPath = current.src.path.replace('node_modules/' + repoName + '/', ''),
-							line = current.src.line ? '#L' + (current.src.line + 1) : '';
+            var nodeModulesFolderNameRegex = /^node_modules\/([\w-]+)\/.*/,
+              folderNameMatches = current.src.path.match(nodeModulesFolderNameRegex);
 
-						return '//github.com/canjs/' + repoName + '/edit/master/' + srcPath + line;
-				},
+            // find repoName by picking it out of the node_modules path, or we can assume this page is in the root canjs repo
+            // this assumes the npm module name matches the github repository name
+            return folderNameMatches ? folderNameMatches[1] : 'canjs';
+        },
+        sourceLink: function(repoName) {
+            var current = docMapInfo.getCurrent();
+
+            if (!current.src) {
+               return false;
+            }
+
+            var srcPath = current.src.path.replace('node_modules/' + repoName + '/', ''),
+              line = current.src.line ? '#L' + (current.src.line + 1) : '';
+
+            return '//github.com/canjs/' + repoName + '/edit/master/' + srcPath + line;
+        },
         customSort: function(children) {
             var ordered = [],
                 sorted = [];

--- a/templates/title.mustache
+++ b/templates/title.mustache
@@ -20,16 +20,16 @@
 				</a>
 			</li>
 			<li>
-			<a class="github-button nav-social" href="https://github.com/canjs/{{name}}"
-				data-count-href="/canjs/{{name}}/stargazers"
-				data-count-api="/repos/canjs/{{name}}#stargazers_count">Star</a>
-	  	</li>
+				<a class="github-button nav-social" href="https://github.com/canjs/{{repoName}}"
+				   data-count-href="/canjs/{{repoName}}/stargazers"
+				   data-count-api="/repos/canjs/{{repoName}}#stargazers_count">Star</a>
+			</li>
 		</ul>
 	{{/if}}
 	{{#with (getClosestWithPackage)}}
 		<ul class="title-links">
 			<!-- <li><a href="#">docco</a></li> -->
-			<li><a href="{{sourceLink}}">Edit on GitHub</a></li>
+			<li><a href="{{sourceLink (repoName)}}">Edit on GitHub</a></li>
 			<!-- <li><a href="#">download</a></li> -->
 			<!-- <li><a href="#">tests</a></li> -->
 		</ul>

--- a/templates/title.mustache
+++ b/templates/title.mustache
@@ -29,7 +29,7 @@
 	{{#with (getClosestWithPackage)}}
 		<ul class="title-links">
 			<!-- <li><a href="#">docco</a></li> -->
-			{{#with (sourceLink .)}}<li><a href="{{.}}">Edit on GitHub</a></li>{{/with}}
+			<li><a href="{{sourceLink}}">Edit on GitHub</a></li>
 			<!-- <li><a href="#">download</a></li> -->
 			<!-- <li><a href="#">tests</a></li> -->
 		</ul>

--- a/templates/title.mustache
+++ b/templates/title.mustache
@@ -20,18 +20,18 @@
 				</a>
 			</li>
 			<li>
-				<a class="github-button nav-social" href="https://github.com/canjs/{{repoName}}"
-				   data-count-href="/canjs/{{repoName}}/stargazers"
-				   data-count-api="/repos/canjs/{{repoName}}#stargazers_count">Star</a>
+				<a class="github-button nav-social" href="https://github.com/canjs/{{repoName src.path}}"
+				   data-count-href="/canjs/{{repoName src.path}}/stargazers"
+				   data-count-api="/repos/canjs/{{repoName src.path}}#stargazers_count">Star</a>
 			</li>
 		</ul>
 	{{/if}}
-	{{#with (getClosestWithPackage)}}
+	{{#if src.path}}
 		<ul class="title-links">
 			<!-- <li><a href="#">docco</a></li> -->
-			<li><a href="{{sourceLink (repoName)}}">Edit on GitHub</a></li>
+			<li><a href="{{sourceLink src (repoName src.path)}}">Edit on GitHub</a></li>
 			<!-- <li><a href="#">download</a></li> -->
 			<!-- <li><a href="#">tests</a></li> -->
 		</ul>
-	{{/with}}
+	{{/if}}
 </section>


### PR DESCRIPTION
Resolves #255.

Assumes the page parent repository is either the same as the NPM module name in the path to the page, or if the page is not inside node_modules, the repository is 'canjs'.