### PR TITLE
Fixed double escaped characters in search

### DIFF
--- a/static/templates/search-results.stache
+++ b/static/templates/search-results.stache
@@ -28,7 +28,7 @@
 
           {{#if result.description}}
             <div class="result-description" title="{{result.description}}">
-              {{result.description}}
+              {{{result.description}}}
             </div>
           {{/if}}
         </li>


### PR DESCRIPTION
Originally I had fixed the double escaping here bit-docs/bit-docs-generate-searchmap#4, but CommonMark encodes entities and had no option to disable that functionality so I have opted to fix it here instead.
![image](https://cloud.githubusercontent.com/assets/6282922/26513052/4c1e9b92-421e-11e7-8b3e-88b36228fb76.png)
