### PR TITLE
Align the search icon and placeholder

### DIFF
--- a/static/search.less
+++ b/static/search.less
@@ -43,7 +43,8 @@
 			color: #ffffff;
 			border: none;
 			padding: 0;
-			// text-indent: 1.5em;
+			position: relative;
+			bottom: 2px;
 			.placeholder(@gray);
 			&:focus{
 				outline:none;


### PR DESCRIPTION
Moved search input up by `2px` under the advice of @jamiemccue.

__Before:__
![image](https://cloud.githubusercontent.com/assets/6282922/26739192/bbec2806-4785-11e7-9f8f-1a4193d8f59e.png)

__After:__
![screen shot 2017-06-02 at 11 15 59 am](https://cloud.githubusercontent.com/assets/6282922/26738950/eb90fe8e-4784-11e7-823c-355d6f18ef32.png)


