### PR TITLE
Fix opening search animation

### DIFF
--- a/static/layout.less
+++ b/static/layout.less
@@ -12,7 +12,7 @@
   position: fixed;
   width: @sidebar-width;
   min-width: 0;
-  transition: min-width 0.4s ease;
+  transition: min-width @transition-speed ease;
   @media screen and (min-width: @breakpoint){
     flex-shrink: 0;
     padding: 0px;

--- a/static/layout.less
+++ b/static/layout.less
@@ -18,10 +18,11 @@
     padding: 0px;
     position: relative;
     width: auto;
+
+    &.search-showing {
+      min-width: 300px !important;
+    }
   }
-}
-#left.search-showing {
-  min-width: 300px !important;
 }
 #right {
   height: 100%;

--- a/static/search.js
+++ b/static/search.js
@@ -30,7 +30,7 @@ var Search = Control.extend({
 		keyboardActiveClass: "keyboard-active",
 
 		//search options
-		searchAnimation: 400,
+		searchAnimation: 250,// matches @transition-speed in variables.less
 		searchTimeout: 400,
 
 		localStorageKeyPrefix: "search",

--- a/static/search.js
+++ b/static/search.js
@@ -473,11 +473,8 @@ var Search = Control.extend({
 	},
 
 	//cancel search on cancel click
-	".search-icon-cancel click": function(el, ev){
-		ev.preventDefault();
-		ev.stopPropagation();
-		this.clear();
-	},
+	".search-icon-cancel click": "clear",
+	".search-icon-cancel touchend": "clear",
 
 	// ---- END EVENTS ---- //
 
@@ -574,7 +571,11 @@ var Search = Control.extend({
 	// function clear
 	// - clears & focuses the input
 	// - unsets the search state
-	clear: function(){
+	clear: function(element, event) {
+		if (event) {
+			event.preventDefault();
+			event.stopPropagation();
+		}
 		this.$input.val("").trigger("focus");
 		this.unsetSearchState();
 	},

--- a/static/search.js
+++ b/static/search.js
@@ -30,6 +30,7 @@ var Search = Control.extend({
 		keyboardActiveClass: "keyboard-active",
 
 		//search options
+		searchAnimation: 400,
 		searchTimeout: 400,
 
 		localStorageKeyPrefix: "search",
@@ -85,7 +86,7 @@ var Search = Control.extend({
 
 					//show the search input when the search engine is ready
 					if(self.options.animateInOnStart){
-						self.$inputWrap.fadeIn(400);
+						self.$inputWrap.fadeIn(self.options.searchAnimation);
 					}else{
 						self.$inputWrap.show();
 					}
@@ -599,7 +600,7 @@ var Search = Control.extend({
 			this.deactivateResult();
 			$('#left').removeClass('search-showing');
 			this.$resultsContainer.stop().addClass("is-hiding").fadeOut({
-				duration: 400,
+				duration: this.options.searchAnimation,
 				complete: function(){
 					self.$resultsContainer.removeClass("is-hiding");
 					if(!self.$resultsContainer.is(".is-showing")){
@@ -626,7 +627,7 @@ var Search = Control.extend({
 			}
 			this.$resultsContainerParent.stop().addClass("search-active");
 			this.$resultsContainer.addClass("is-showing").fadeIn({
-				duration: 400,
+				duration: this.options.searchAnimation,
 				complete: function(){
 					if(!self.$resultsContainer.is(".is-hiding")){
 						self.$resultsContainer.removeClass("is-showing");

--- a/static/search.less
+++ b/static/search.less
@@ -34,7 +34,7 @@
 		}
 
 		.search{
-			transition: width 0.4s ease;
+			transition: width @transition-speed ease;
 			background: @code-color;
 			color: #ffffff;
 			border: none;
@@ -66,6 +66,7 @@
 		left: 0;
 		overflow-y: auto;
 		padding: 2em 0;
+		transition: -webkit-backdrop-filter backdrop-filter background @transition-speed ease;
 		z-index: 1;
 		.search-cancel{
 			color: @code-color;
@@ -136,5 +137,13 @@
 	&.search-active{
 		overflow-y:hidden;
 		position:relative;
+	}
+}
+
+@supports (-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px)) {
+	.bottom-left .search-results-container {
+		-webkit-backdrop-filter: @backdrop-blur;
+		backdrop-filter: @backdrop-blur;
+		background: rgba(100%, 100%, 100%, .65);
 	}
 }

--- a/static/search.less
+++ b/static/search.less
@@ -6,13 +6,10 @@
 	cursor:pointer;
 
 	.search-wrap{
-		position: relative;
-		padding: 0 1.5em;
+		display: flex;
+
 		.search-icon{
 			display: block;
-			position: absolute;
-			top: 1px;
-			left: 0;
 			height: 1em;
 			width: 1em;
 			font-size: 1em;
@@ -23,12 +20,11 @@
 		}
 		.search-icon-cancel{
 			display: block;
-			position: absolute;
-			right: 0;
+			position: relative;
 			height: 1em;
 			width: 1em;
 			font-size: .8em;
-			top: 0.25em;
+			top: 0.125em;
 			cursor: pointer;
 			background-color: @code-color;
 			background-image: url(img/icon-x-white.svg);
@@ -36,16 +32,16 @@
 			background-repeat: no-repeat;
 			display:none;
 		}
-		
+
 		.search{
 			transition: width 0.4s ease;
 			background: @code-color;
 			color: #ffffff;
 			border: none;
-			padding: 0;
+			padding: 0 .5em;
 			position: relative;
-			bottom: 2px;
-			width: 40px;
+			bottom: 0.125em;
+			flex: 1;
 			.placeholder(@gray);
 			&:focus{
 				outline:none;
@@ -55,19 +51,7 @@
 		&.has-value .search-icon-cancel{
 			display:block;
 		}
-		@media screen and (max-width: @breakpoint) {
-			&.has-value{
-				width: 200px;
-			}
-		}
 	}
-	@media screen and (min-width: @breakpoint) {
-		display: block;
-	}
-}
-
-#left.search-showing .search-bar .search-wrap .search {
-	width: 100%;
 }
 
 .bottom-left{
@@ -90,9 +74,6 @@
 			padding: .5em;
 			font-size: 1em;
 			line-height: 1;
-			position: absolute;
-			top: 0;
-			right: 0;
 		}
 
 		ul{

--- a/static/search.less
+++ b/static/search.less
@@ -7,6 +7,8 @@
 
 	.search-wrap{
 		display: flex;
+		position: relative;
+		top: 1px;
 
 		.search-icon{
 			display: block;
@@ -38,8 +40,6 @@
 			color: #ffffff;
 			border: none;
 			padding: 0 .5em;
-			position: relative;
-			bottom: 0.125em;
 			flex: 1;
 			.placeholder(@gray);
 			&:focus{

--- a/static/search.less
+++ b/static/search.less
@@ -19,7 +19,6 @@
 			background-repeat: no-repeat;
 		}
 		.search-icon-cancel{
-			display: block;
 			position: relative;
 			height: 1em;
 			width: 1em;

--- a/static/sidebar.less
+++ b/static/sidebar.less
@@ -1,18 +1,3 @@
-.search-bar {
-	background: @code-color;
-	padding: @gutter @gutter*2;
-	height: 48px;
-	p {
-		border: none;
-		margin: 0px;
-		color: white;
-		font-weight: 300;
-	}
-	@media screen and (min-width: @breakpoint) {
-		display: block;
-	}
-}
-
 // ----- SOCIAL BUTTONS FOR MOBILE VIEW -----
 ul.social-side{
 	margin: 0;

--- a/static/variables.less
+++ b/static/variables.less
@@ -18,3 +18,6 @@
 
 /*----- TYPE -----*/
 @font-weight-heading: 500;
+
+/*----- OTHER -----*/
+@backdrop-blur: saturate(180%) blur(20px);

--- a/templates/search-bar.mustache
+++ b/templates/search-bar.mustache
@@ -1,9 +1,9 @@
 <div class="search-bar">
 	<div class="search-wrap" style="display:none;">
 		<span class="search-icon"></span>
-		<span class="search-icon-cancel"></span>
 		<input
 			type="text"
+			size="6"
 			class="search"
 			placeholder="Search"
 			autocomplete="off"
@@ -11,4 +11,5 @@
 			autocapitalize="none"
 			spellcheck="false"/>
 	</div>
+	<span class="search-icon-cancel"></span>
 </div>

--- a/templates/search-bar.mustache
+++ b/templates/search-bar.mustache
@@ -10,6 +10,6 @@
 			autocorrect="off"
 			autocapitalize="none"
 			spellcheck="false"/>
+			<span class="search-icon-cancel"></span>
 	</div>
-	<span class="search-icon-cancel"></span>
 </div>


### PR DESCRIPTION
Previously, when the user would start a new search and the results would open, the sidebar would jump to a specific width and then animate the rest of the width change.

This fixes the styles so the sidebar animates smoothly to its new width.