### PR TITLE
Escape the description

### DIFF
--- a/static/templates/search-results.stache
+++ b/static/templates/search-results.stache
@@ -23,12 +23,12 @@
           {{#if result.title}}
           <span class="name">
 						({{result.name}})
-          </span>	
+          </span>
           {{/if}}
 
           {{#if result.description}}
             <div class="result-description" title="{{result.description}}">
-              {{{result.description}}}
+              {{result.description}}
             </div>
           {{/if}}
         </li>


### PR DESCRIPTION
This prevents html elements that should show up as code from being inserted into the DOM.

Before:
<img width="302" alt="screen shot 2017-06-05 at 6 21 20 pm" src="https://cloud.githubusercontent.com/assets/10070176/26809794/33699f06-4a1c-11e7-8dc3-834db4e241d0.png">

After:
<img width="303" alt="screen shot 2017-06-05 at 6 22 18 pm" src="https://cloud.githubusercontent.com/assets/10070176/26809797/37c4925e-4a1c-11e7-8c91-09a51dda7da9.png">
