### PR TITLE
Removed width atribute

### DIFF
--- a/static/content.less
+++ b/static/content.less
@@ -109,7 +109,6 @@ article {
         margin-bottom: @gutter;
         &:before {
           display: inline-block;
-          width: 1em;
           padding-right: 0.5em;
           font-weight: bold;
           text-align: right;


### PR DESCRIPTION
I don't think this was needed and it was causing a little style bug.
__Before__:
![image](https://user-images.githubusercontent.com/6282922/27192631-f72ffc46-51b0-11e7-835e-57073d5d611e.png)
__After__:
![image](https://user-images.githubusercontent.com/6282922/27192639-fbe5d77e-51b0-11e7-8332-e4bd7b250d41.png)
