### PR TITLE
Make search links relative

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bit-docs-html-canjs",
-  "version": "1.0.1",
+  "version": "1.0.2-0",
   "description": "The plugins to produce the CanJS site",
   "main": "static/canjs",
   "scripts": {

--- a/static/canjs.js
+++ b/static/canjs.js
@@ -95,7 +95,7 @@ function init() {
 				window.history.pushState(null, null, href);
 				navigate(href);
 			},
-			pathPrefix: '/doc',
+			pathPrefix: window.pathPrefix,
 			animateInOnStart: !hasShownSearch
 		});
 	}
@@ -237,6 +237,11 @@ function navigate(href) {
 
 			init();
 			setDocTitle();
+
+			searchControl.options.pathPrefix = window.pathPrefix;
+			if(searchControl.searchResultsCache){
+				searchControl.renderSearchResults(searchControl.searchResultsCache);
+			}
 		},
 		error: function() {
 			// just reload the page if this fails

--- a/static/search.js
+++ b/static/search.js
@@ -59,6 +59,7 @@ var Search = Control.extend({
 
 	storageFallback: {},
 	useLocalStorage: false,
+	searchResultsCache: null,
 
 	// ---- END PROPERTIES ---- //
 
@@ -502,40 +503,45 @@ var Search = Control.extend({
 		var self = this;
 		this.searchDebounceHandle = setTimeout(function(){
 			self.searchEngineSearch(value).then(function(results) {
-				var numResults = results.length;
-				if (numResults > 50) {
-					numResults = '50+';
-					results = results.slice(0, 50);
-				}
-				var resultsFrag = self.options.resultsRenderer({
-					results: results,
-					numResults: numResults,
-					searchValue:value,
-					pathPrefix: (self.options.pathPrefix === '.') ? '' : '/' + self.options.pathPrefix + '/'
-				},{
-					docUrl: function(){
-						if(self.options.pathPrefix){
-							return self.options.pathPrefix + "/" + this.url;
-						}
-				
-						if(this.url.substr(-1) === "/"){
-							return this.url;
-						}
-
-						return "/" + this.url;
-					}
-				});
-
-				self.$resultsWrap.empty();
-				self.$resultsWrap[0].appendChild(resultsFrag);
-
-				//refresh necessary dom
-				self.$resultsList = null;
-				if(numResults){
-					self.$resultsList = self.$resultsWrap.find(".search-results > ul");
-				}
+				self.searchResultsCache = results;
+				self.renderSearchResults(results);
 			});
 		}, this.options.searchTimeout);
+	},
+
+	renderSearchResults: function(results){
+		var self = this;
+		var numResults = results.length;
+		if (numResults > 50) {
+			numResults = '50+';
+			results = results.slice(0, 50);
+		}
+		var resultsFrag = this.options.resultsRenderer({
+			results: results,
+			numResults: numResults,
+			searchValue: this.searchTerm
+		},{
+			docUrl: function(){
+				if(self.options.pathPrefix){
+					return self.options.pathPrefix + "/" + this.url;
+				}
+
+				if(this.url.substr(-1) === "/"){
+					return this.url;
+				}
+
+				return "/" + this.url;
+			}
+		});
+
+		this.$resultsWrap.empty();
+		this.$resultsWrap[0].appendChild(resultsFrag);
+
+		//refresh necessary dom
+		this.$resultsList = null;
+		if(numResults){
+			this.$resultsList = this.$resultsWrap.find(".search-results > ul");
+		}
 	},
 
 	// ---- SHOW/HIDE ---- //


### PR DESCRIPTION
Since we want the site to work when hosted from a parent folder, and the search results persist through navigation, the `pathPrefix` must be dynamically set and the results must be re-rendered when navigation occurs to ensure links don't point to the next directory up e.g. `/doc/...` instead of `/canjs/doc/...` .