### PR TITLE
Fix escaping in search results and added styles

### DIFF
--- a/static/search.less
+++ b/static/search.less
@@ -84,6 +84,7 @@
 				a{
 					color: @link-color;
 					padding-bottom:0;
+					display: inline-block;
 					&:hover {
 						text-decoration: none;
 					}
@@ -109,6 +110,9 @@
 					margin-top: .3em;
 					overflow: hidden;
 					text-overflow: ellipsis;
+				}
+				code {
+					background-color: inherit;
 				}
 				&:hover,
 				&.keyboard-active{

--- a/templates/search-results.stache
+++ b/templates/search-results.stache
@@ -28,7 +28,7 @@
 
             {{#if result.description}}
               <div class="result-description" title="{{result.description}}">
-                {{result.description}}
+                {{{result.description}}}
               </div>
             {{/if}}
           </a>


### PR DESCRIPTION
__Before:__
![image](https://user-images.githubusercontent.com/6282922/27460715-a5f278c6-576a-11e7-9f11-6641446ea3a7.png)
__After:__
![image](https://user-images.githubusercontent.com/6282922/27460723-ad6e3d92-576a-11e7-914b-453491fb0007.png)
