### PR TITLE
Toggle focused checkbox elements on enter keypress

### DIFF
--- a/static/canjs.js
+++ b/static/canjs.js
@@ -14,6 +14,8 @@ var $articleContainer,
 	$headers,
 	$nav,
 	$pathPrefix,
+	$navTrigger,
+	$navLabel,
 	headerHidden,
 	animating,
 	navigating,
@@ -46,7 +48,14 @@ var $articleContainer,
 		var $target = $(e.target);
 		if(e.keyCode == 13 && $target.is(document.activeElement)){
 			$target.prop('checked', !$target.prop('checked'));
+			$target.trigger('change');
 		}
+	});
+
+	$navTrigger.focus(function(){
+		$navTrigger.siblings('label').addClass('active');
+	}).blur(function(){
+		$navTrigger.siblings('label').removeClass('active');
 	});
 
 	// Back/Forward navigation
@@ -78,6 +87,7 @@ function init() {
 	// Set state
 	$articleContainer = $('#right .bottom-right');
 	$onThisPage = $('.on-this-page');
+	$navTrigger = $('#nav-trigger');
 	$onThisPageTitle = $('.breadcrumb-dropdown a');
 	$tableOfContents = $('.on-this-page-table');
 	$everything = $('#everything');

--- a/static/canjs.js
+++ b/static/canjs.js
@@ -42,6 +42,11 @@ var $articleContainer,
 			var href = this.href;
 			navigate(href);
 		}
+	}).on('keyup', 'input[type="checkbox"]', function(e){
+		var $target = $(e.target);
+		if(e.keyCode == 13 && $target.is(document.activeElement)){
+			$target.prop('checked', !$target.prop('checked'));
+		}
 	});
 
 	// Back/Forward navigation

--- a/static/mobile.less
+++ b/static/mobile.less
@@ -18,6 +18,9 @@ label[for="nav-trigger"] {
   .border-radius;
   z-index: 99;
   transition: background @transition-speed;
+  &.active {
+    outline: #3092eb auto 5px;
+  }
 }
 label:hover{
   background: @border-color;


### PR DESCRIPTION
The CanJS menu uses an `<input type="checkbox">` wrapped with a `<label>` with some fancy CSS. No JS whatsoever. The native behavior of a browser does not check a focused checkbox when the user presses enter.
![image](https://user-images.githubusercontent.com/6282922/27493909-6acfdab8-5800-11e7-84bd-6768fc32265c.png)
