### PR TITLE
Bump the search index version

### DIFF
--- a/static/search.js
+++ b/static/search.js
@@ -315,7 +315,7 @@ var Search = Control.extend({
 		var searchIndexVersionKey = this.formatLocalStorageKey(this.searchIndexVersionLocalStorageKey);
 		var index = this.getLocalStorageItem(searchIndexKey);
 		var indexVersion = this.getLocalStorageItem(searchIndexVersionKey);
-		var currentIndexVersion = 2;// Bump this whenever the index code is changed
+		var currentIndexVersion = 3;// Bump this whenever the index code is changed
 
 		if (index && currentIndexVersion === indexVersion) {
 			searchEngine = lunr.Index.load(index);


### PR DESCRIPTION
I just realized that the number wasn’t bumped when [these changes](https://github.com/canjs/bit-docs-html-canjs/commit/00d068d2423f2ab123440fd0587366fb2c2c991d) were made, so bumping it now.