### PR TITLE
Fix test pathPrefix

### DIFF
--- a/test/search.js
+++ b/test/search.js
@@ -18,7 +18,7 @@ document.body.appendChild(searchBar);
 
 /* Create a new instance of the search control */
 var search = new SearchControl('#search-bar', {
-  pathPrefix: '/doc'
+  pathPrefix: '../doc'
 });
 
 /* Tests */


### PR DESCRIPTION
When hosting the site from a parent folder, `/doc` will lead to a 404. `../doc` will look up 1 folder from `/test` so it will work with or without a parent folder.