### PR TITLE
Fixed bug that removed all HTML from search results

### DIFF
--- a/static/search.js
+++ b/static/search.js
@@ -1,4 +1,5 @@
 var $ = require("jquery");
+var assign = require("can-util/js/assign/");
 var Control = require("can-control");
 var LoadingBar = require('./loading-bar');
 var searchResultsRenderer = require("../templates/search-results.stache!steal-stache");
@@ -374,7 +375,7 @@ var Search = Control.extend({
 
 		for (var itemKey in searchMap) {
 			if (searchMap.hasOwnProperty(itemKey)) {
-				var item = searchMap[itemKey];
+				var item = assign({}, searchMap[itemKey]);
 
 				// Convert HTML to text
 				dummyContainer.innerHTML = item.description;


### PR DESCRIPTION
When I fixed the Safari bug, I inadvertently sanitized the descriptions that are printed to the UI.