### PR TITLE
Fix a bug causing resources with relative paths to load the wrong URL

### DIFF
--- a/static/canjs.js
+++ b/static/canjs.js
@@ -195,6 +195,8 @@ function navigate(href) {
         return;
     }
 
+	window.history.pushState(null, null, href);
+
 	// clear existing scroll interval if it's still alive
 	clearInterval(scrollPositionInterval);
 
@@ -270,8 +272,6 @@ function navigate(href) {
 			if(searchControl.searchResultsCache){
 				searchControl.renderSearchResults(searchControl.searchResultsCache);
 			}
-      
-      window.history.pushState(null, null, href);
 		},
 		error: function() {
 			window.history.pushState(null, null, href);

--- a/static/canjs.js
+++ b/static/canjs.js
@@ -195,8 +195,6 @@ function navigate(href) {
         return;
     }
 
-	window.history.pushState(null, null, href);
-
 	// clear existing scroll interval if it's still alive
 	clearInterval(scrollPositionInterval);
 
@@ -220,6 +218,9 @@ function navigate(href) {
 			return xhr;
 		},
 		success: function(content) {
+			
+			window.history.pushState(null, null, href);
+
 			// Google Analytics
 			ga('send', 'pageview', window.location.pathname);
 


### PR DESCRIPTION
We highjack clicks on `<a>` tags and use Ajax to load the content in. If we don't change the URL with `pushState` before we load the content into the DOM, all relative paths will be based off the previous page's URL. This causing the issue Justin reported in slack: https://bitovi.slack.com/archives/C09R50SAE/p1499289090158230