### PR TITLE
Remove ugly scroll bar in the search results

### DIFF
--- a/static/sidebar.less
+++ b/static/sidebar.less
@@ -81,7 +81,7 @@ img.social-icon-small{
 	// Highest parent level
 	.nav-menu { 
 		height: inherit;
-		overflow-y: scroll;
+		overflow-y: auto;
 		& > .scrollable-contents {
 			padding: @gutter*2;
 			& > ul {


### PR DESCRIPTION
In some browser/OS combinations, an ugly scroll bar shows up in the sidebar.
![image](https://user-images.githubusercontent.com/6282922/27886662-edb5e0d6-6191-11e7-9f01-3bbbc09891dc.png)
