### PR TITLE
Don’t go to the first result after keyboarding past the last result

### DIFF
--- a/static/search.js
+++ b/static/search.js
@@ -664,13 +664,9 @@ var Search = Control.extend({
 
 		$nextResult = this.$activeResult.next("li");
 
-		//if no next result,
-		//  activate the first one
-		if(!$nextResult || ($nextResult && !$nextResult.length)){
-			this.activateResult(this.$resultsList.find("li").first());
-			return;
+		if ($nextResult && $nextResult.length) {
+			this.activateResult($nextResult);
 		}
-		this.activateResult($nextResult);
 	},
 	// function activateNextResult
 	// finds the previous result in the results to activate
@@ -693,13 +689,9 @@ var Search = Control.extend({
 
 		$prevResult = this.$activeResult.prev("li");
 
-		//if no prev result,
-		//  activate the last one
-		if(!$prevResult || ($prevResult && !$prevResult.length)){
-			this.activateResult(this.$resultsList.find("li").last());
-			return;
+		if ($prevResult && $prevResult.length) {
+			this.activateResult($prevResult);
 		}
-		this.activateResult($prevResult);
 	},
 
 	// function activateResult

--- a/static/search.js
+++ b/static/search.js
@@ -704,16 +704,18 @@ var Search = Control.extend({
 		this.$activeResult.addClass(this.options.keyboardActiveClass);
 
 		// Get position top of current active element
-		var activeResultPosTop = parseInt(this.$activeResult.position().top);
+		var activeResultPosTop = parseInt(this.$activeResult.position().top, 10);
+		var activeResultHeight = Math.ceil(this.$activeResult.outerHeight());
+		var activeResultPosBottom = activeResultPosTop + activeResultHeight;
 		var resultsContainerHeight = this.$resultsContainer.height();
 
 		// Detect if the user is arrowing down
 		var isMovingDown = lastResultPosTop < this.$activeResult.position().top;
-		var isBelow = activeResultPosTop > resultsContainerHeight;
+		var isBelow = activeResultPosBottom > resultsContainerHeight;
 		var isAbove = activeResultPosTop < 0;
 
 		if(isMovingDown && isBelow){
-			this.resetScrollToBottom(activeResultPosTop, resultsContainerHeight);
+			this.resetScrollToBottom(activeResultPosBottom, resultsContainerHeight);
 		}
 		else if(isAbove){
 			this.resetScrollToTop(activeResultPosTop);
@@ -727,11 +729,9 @@ var Search = Control.extend({
 		);
 	},
 
-	resetScrollToBottom: function(activeResultPosTop, resultsContainerHeight){
-		// Calculate active result's position bottom
-		var scrollTo = (activeResultPosTop + this.$activeResult.outerHeight()) -
-		// Calculate the current scrolled position of the bottom of the list
-		(this.getActiveResultOffset() + resultsContainerHeight);
+	resetScrollToBottom: function(activeResultPosBottom, resultsContainerHeight){
+		var currentScrollTop = this.$resultsContainer.scrollTop();
+		var scrollTo = activeResultPosBottom - resultsContainerHeight + currentScrollTop;
 
 		this.$resultsContainer.scrollTop(scrollTo);
 	},
@@ -756,22 +756,6 @@ var Search = Control.extend({
 				href = $a.attr("href");
 
 		this.navigate(href);
-	},
-
-	// function getActiveResultOffset
-	// if method provided, use the return value
-	// otherwise, use the position().top of the first list item
-	getActiveResultOffset: function(){
-
-		if(this.options.getActiveResultOffset){
-			return this.options.getActiveResultOffset();
-		}
-
-		var $item = this.$resultsList.find("li").first();
-		if(!$item || ($item && !$item.length)){
-			return 0;
-		}
-		return $item.position().top;
 	},
 
 	// ---- END KEYBOARD NAVIGATION ---- //

--- a/static/search.less
+++ b/static/search.less
@@ -79,13 +79,16 @@
 		ul{
 			padding:0;
 			> li{
-				padding: .9em .5em;
 				border-bottom: 1px solid @light-gray-color;
 				a{
 					display: inline;
 					&:hover {
 						text-decoration: none;
 					}
+				}
+				> a {
+					display: block;
+					padding: .9em .5em;
 				}
 				.name{
 					line-height: 1;

--- a/static/search.less
+++ b/static/search.less
@@ -64,7 +64,6 @@
 		background: #fff;
 		left: 0;
 		overflow-y: auto;
-		padding: 2em 0;
 		transition: -webkit-backdrop-filter backdrop-filter background @transition-speed ease;
 		z-index: 1;
 		.search-cancel{
@@ -124,9 +123,8 @@
 		}
 
 		.search-results-heading{
-			padding:0 .5em;
 			border-bottom: 1px solid @light-gray-color;
-			padding-bottom: 1em;
+			padding: 1em .5em;
 			.count{
 				font-weight:bold;
 			}


### PR DESCRIPTION
Similarly, don’t go to the last result after keyboarding past the first result.

Also:

- Make the entire area around a search result clickable. Previously, only the text was clickable to select a search result.
- Remove extraneous padding from the top and bottom of the search results