### PR TITLE
Handle edge case where a page doesn’t have a nav

### DIFF
--- a/static/canjs.js
+++ b/static/canjs.js
@@ -75,7 +75,7 @@ var $articleContainer,
 	setInterval(function() {
 		toggleNav();
 	}, 200);
-	
+
 	scrollToCurrentMenuItem();
 })();
 
@@ -216,9 +216,9 @@ function navigate(href, updateLocation) {
 			return xhr;
 		},
 		success: function(content) {
-			
+
 			if(updateLocation !== false){
-				window.history.pushState(null, null, href);	
+				window.history.pushState(null, null, href);
 			}
 
 			// Google Analytics
@@ -241,10 +241,12 @@ function navigate(href, updateLocation) {
 
 			//if any page doesn't have a nav, replacing it won't work,
 			//and the nav will be gone for any subsequent page visits
-			if($navReplace && $navReplace.length){
-				$navReplace.replaceWith($nav);
-			}else{
-				$(".bottom-left").append($nav);
+			if ($nav && $nav.length) {
+				if ($navReplace && $navReplace.length) {
+					$navReplace.replaceWith($nav);
+				} else {
+					$(".bottom-left").append($nav);
+				}
 			}
 			$("article").replaceWith($article);
 			$(".breadcrumb").replaceWith($breadcrumb);


### PR DESCRIPTION
If a page is loaded and it doesn’t have a nav, then we won’t try to replace the current nav.

Before:
![before](https://user-images.githubusercontent.com/10070176/28133402-c14f4146-66f4-11e7-811f-62dac766a4e3.gif)

After:
![after](https://user-images.githubusercontent.com/10070176/28133404-c668e434-66f4-11e7-84ac-9583a7a06d29.gif)
