### PR TITLE
Fix the search results overlay in Safari

### DIFF
--- a/static/breadcrumb.less
+++ b/static/breadcrumb.less
@@ -1,7 +1,7 @@
 .breadcrumb {
 	display: none;
 	@media screen and (min-width: @breakpoint) {
-		height: 48px;
+		height: @breadcrumb-height;
 		display: block;
 		padding-left: @gutter*2;
 		background: @code-color;

--- a/static/canjs.js
+++ b/static/canjs.js
@@ -86,7 +86,7 @@ $('body').on('touchstart', function() {});
 
 function init() {
 	// Set state
-	$articleContainer = $('#right .bottom-right');
+	$articleContainer = $('#right > .bottom');
 	$onThisPage = $('.on-this-page');
 	$navTrigger = $('#nav-trigger');
 	$onThisPageTitle = $('.breadcrumb-dropdown a');
@@ -229,11 +229,11 @@ function navigate(href, updateLocation) {
 			if (!$content.length) {
 				window.location.reload();
 			}
-			var $nav = $content.find(".bottom-left .scrollable-contents > ul"),
+			var $nav = $content.find("#left > .bottom .nav-menu > ul"),
 					$article = $content.find("article"),
 					$breadcrumb = $content.find(".breadcrumb"),
 					homeLink = $content.find(".logo > a").attr('href'),
-					$navReplace = $(".bottom-left .scrollable-contents > ul"),
+					$navReplace = $("#left > .bottom .nav-menu > ul"),
 
 					//root elements - use .filter; not .find
 					$pathPrefixDiv = $content.filter("[path-prefix]");
@@ -245,7 +245,7 @@ function navigate(href, updateLocation) {
 				if ($navReplace && $navReplace.length) {
 					$navReplace.replaceWith($nav);
 				} else {
-					$(".bottom-left").append($nav);
+					$("#left > .bottom").append($nav);
 				}
 			}
 			$("article").replaceWith($article);

--- a/static/header.less
+++ b/static/header.less
@@ -1,13 +1,13 @@
 .top-right-top {
     display: inline-flex;
     flex-direction: row-reverse;
+    height: @brand-height;
     width: 100%;
-    height: 53px;
     justify-content: space-between;
 }
 
 .brand {
-    height: 53px;
+    height: @brand-height;
     padding-top: @gutter;
     background: white;
 
@@ -154,7 +154,7 @@
             .border;
             border-top: none;
             right: 0;
-            top: 53px;
+            top: @brand-height;
             list-style: none;
             padding: 0;
             width: 240px;

--- a/static/layout.less
+++ b/static/layout.less
@@ -65,15 +65,8 @@
     border: none;
   }
 }
-.bottom-left {
+.bottom {
   flex-grow: 1;
-  background: white;
-  height: inherit;
   overflow-x: hidden;
   overflow-y: auto;
-}
-.bottom-right {
-  flex-grow: 1;
-  overflow-y: auto;
-  overflow-x: hidden;
 }

--- a/static/search.js
+++ b/static/search.js
@@ -11,7 +11,7 @@ var Search = Control.extend({
 	defaults: {
 		//dom selectors
 		searchResultsContainerSelector: ".search-results-container",
-		searchResultsContainerParentSelector: ".bottom-left",
+		searchResultsContainerParentSelector: "#left > .bottom",
 
 		//renderer stuff
 		resultsRenderer: searchResultsRenderer,
@@ -498,7 +498,7 @@ var Search = Control.extend({
 		var self = this;
 		this.searchDebounceHandle = setTimeout(function(){
 			if (!self.searchIndicator) {
-				self.searchIndicator = new LoadingBar('blue', self.$resultsContainerParent);
+				self.searchIndicator = new LoadingBar('blue', self.$resultsContainer);
 			}
 			self.searchIndicator.start(0);
 			self.searchIndicator.update(100);
@@ -599,7 +599,6 @@ var Search = Control.extend({
 				complete: function(){
 					self.$resultsContainer.removeClass("is-hiding");
 					if(!self.$resultsContainer.is(".is-showing")){
-						self.$resultsContainerParent.removeClass("search-active");
 						if(self.$resultsWrap && self.$resultsWrap.length){
 							self.$resultsWrap.empty();
 						}
@@ -620,7 +619,7 @@ var Search = Control.extend({
 			if(this.options.onResultsShow){
 				this.options.onResultsShow();
 			}
-			this.$resultsContainerParent.stop().addClass("search-active");
+			this.$resultsContainerParent.stop();
 			this.$resultsContainer.addClass("is-showing").fadeIn({
 				duration: this.options.searchAnimation,
 				complete: function(){

--- a/static/search.less
+++ b/static/search.less
@@ -1,8 +1,8 @@
  //Search
 .search-bar {
 	background: @code-color;
+	height: @breadcrumb-height;
 	padding: @gutter @gutter*2;
-	height: 48px;
 	cursor:pointer;
 
 	.search-wrap{
@@ -53,19 +53,25 @@
 	}
 }
 
-.bottom-left{
+#left > .bottom {
 	//Search Results
 	.search-results-container{
 		display:none;
+		height: calc(~"100vh - @{breadcrumb-height}");
 		position: absolute;
+		top: @breadcrumb-height;
 		width: 100%;
-		height: 100%;
-		top: 0;
 		background: #fff;
 		left: 0;
 		overflow-y: auto;
 		transition: -webkit-backdrop-filter backdrop-filter background @transition-speed ease;
-		z-index: 1;
+
+		// Desktop styles
+		@media screen and (min-width: @breakpoint) {
+			height: calc(~"100vh - @{brand-height} - @{breadcrumb-height}");
+			top: @brand-height + @breadcrumb-height;
+		}
+
 		.search-cancel{
 			color: @code-color;
 			display: block;
@@ -139,14 +145,10 @@
 			}
 		}
 	}
-	&.search-active{
-		overflow-y:hidden;
-		position:relative;
-	}
 }
 
 @supports (-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px)) {
-	.bottom-left .search-results-container {
+	#left > .bottom .search-results-container {
 		-webkit-backdrop-filter: @backdrop-blur;
 		-webkit-font-smoothing: subpixel-antialiased;
 		backdrop-filter: @backdrop-blur;

--- a/static/sidebar.less
+++ b/static/sidebar.less
@@ -51,7 +51,7 @@ img.social-icon-small{
 }
 
 // ----- SIDE NAVIGATION -----
-.bottom-left {
+#left > .bottom {
 	ul {
 		padding-left: @gutter/1.5;
 		margin: 0;
@@ -80,46 +80,42 @@ img.social-icon-small{
 	}
 	// Highest parent level
 	.nav-menu {
-		height: inherit;
-		overflow-y: auto;
-		& > .scrollable-contents {
-			padding: @gutter * 2 @gutter * 2 0;
-			& > ul {
+		padding: @gutter * 2 @gutter * 2 0;
+		& > ul {
+			padding: 0;
+			height: inherit;
+			> li {
+				list-style: none;
+				list-style-type: none;
 				padding: 0;
-				height: inherit;
-				> li {
-					list-style: none;
-					list-style-type: none;
-					padding: 0;
-					.border-bottom;
-					> a {
-						font-size: 110%;
-						padding-bottom: @gutter;
-						padding-top: @gutter;
-					}
-					&.expanded > a {
-						padding-bottom: @gutter/3;
-					}
-					// Second level
-					> ul {
-						> li {
+				.border-bottom;
+				> a {
+					font-size: 110%;
+					padding-bottom: @gutter;
+					padding-top: @gutter;
+				}
+				&.expanded > a {
+					padding-bottom: @gutter/3;
+				}
+				// Second level
+				> ul {
+					> li {
+						> a {
+							padding-bottom: @gutter/3;
+							padding-top: @gutter/3;
+						}
+						&.expanded {
 							> a {
-								padding-bottom: @gutter/3;
-								padding-top: @gutter/3;
+								padding-bottom: @gutter/2;
+								margin-left: -1px;
 							}
-							&.expanded {
-								> a {
-									padding-bottom: @gutter/2;
-									margin-left: -1px;
-								}
-							}
-							//Third level
-							> ul {
-								border-left: 1px solid @border-color;
-								li {
-									ul {
-										margin-top: @gutter/3;
-									}
+						}
+						//Third level
+						> ul {
+							border-left: 1px solid @border-color;
+							li {
+								ul {
+									margin-top: @gutter/3;
 								}
 							}
 						}

--- a/static/variables.less
+++ b/static/variables.less
@@ -11,8 +11,10 @@
 @twitter-color: #1da1f2;
 
 /*----- LAYOUT -----*/
-@gutter: 15px;
+@brand-height: 53px;
+@breadcrumb-height: 48px;
 @breakpoint: 1000px;
+@gutter: 15px;
 @sidebar-width: 250px;
 @transition-speed: .25s;
 

--- a/templates/content.mustache
+++ b/templates/content.mustache
@@ -5,16 +5,14 @@
           {{>header-left.mustache}}
       {{/with}}
     </div>
-    <div class="bottom-left">
+    <div class="bottom">
       <div class="nav-menu">
-        <div class="scrollable-contents">
-          <div class="social-side-container">
-            {{>social.mustache}}
-          </div>
-          {{#with (getCurrentTree)}}
-              {{>menu.mustache}}
-          {{/with}}
+        <div class="social-side-container">
+          {{>social.mustache}}
         </div>
+        {{#with (getCurrentTree)}}
+            {{>menu.mustache}}
+        {{/with}}
       </div>
       {{>search-results.mustache}}
     </div>
@@ -23,10 +21,11 @@
     <div class="top-right">
       {{> header-right.mustache}}
     </div>
-    <div class="bottom-right">
+    <div class="bottom">
       <article>{{> article.mustache}}</article>
-	  {{#with (getRoot)}}
+      {{#with (getRoot)}}
         <footer>{{> footer.mustache}}</footer>
-	  {{/with}}    </div>
+      {{/with}}
+    </div>
   </div>
 </div>


### PR DESCRIPTION
Instead of relying on flexbox to correctly lay out the absolutely-positioned overlay, we’re specifying an exact top position and height for it, which consistently renders correctly in all browsers.

I also cleaned up some of the CSS classes and styles.

Before:
![safari bug](https://user-images.githubusercontent.com/10070176/28235819-fd750b9c-68ca-11e7-88c9-868067f45380.gif)

After:
![safari bug fixed](https://user-images.githubusercontent.com/10070176/28286289-8f54fa54-6aec-11e7-9e11-c0db868330b0.gif)

Fixes https://github.com/canjs/bit-docs-html-canjs/issues/383