### PR TITLE
Fix some styles for the “Getting started” section on the home page

### DIFF
--- a/static/home.less
+++ b/static/home.less
@@ -12,8 +12,11 @@
 			& > ul {
 				margin: 0;
 				.icon-list;
-				& > li > a > div {
-					display: inline-block;
+				& > li {
+					margin-bottom: @gutter;
+					& > a > div {
+						display: inline-block;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Before:
<img width="199" alt="screen shot 2017-07-20 at 5 22 52 pm" src="https://user-images.githubusercontent.com/10070176/28444175-1d444876-6d70-11e7-8b87-affc9c269a91.png">

After:
<img width="211" alt="screen shot 2017-07-20 at 5 21 23 pm" src="https://user-images.githubusercontent.com/10070176/28444178-22ce93fa-6d70-11e7-86be-607f9b2525fc.png">

Related to https://github.com/canjs/canjs/issues/3224