### PR TITLE
Fix bug preventing loading indicator from showing

### DIFF
--- a/static/loading-bar.js
+++ b/static/loading-bar.js
@@ -1,5 +1,5 @@
 function LoadingBar(color, parent) {
-  this.meter = $('<span>', {style: 'transition: width 1s ease; width:0%;'});
+  this.meter = $('<span>', {style: 'transition: width 0.5s ease; width:0%;'});
   this.elem = $('<div>', {style: 'display:none', class: 'meter animate ' + color}).append(
     this.meter.append($('<span>'))
   );
@@ -10,18 +10,32 @@ function LoadingBar(color, parent) {
   return this;
 }
 
-LoadingBar.prototype.start = function(percentage) {
-  percentage = percentage || 0;
-  this.meter.css('width', percentage + '%');
+LoadingBar.prototype.start = function(progress) {
+  progress = progress || 5;
+  this.clearTimer();
+  this.meter.css('width', progress + '%');
   this.elem.show();
 };
 
 LoadingBar.prototype.end = function() {
-  this.elem.hide();
+  this.update(100);
 };
 
-LoadingBar.prototype.update = function(percentage) {
-  this.meter.css('width', percentage + '%');
+LoadingBar.prototype.update = function(progress) {
+  this.clearTimer();
+  this.meter.css('width', progress + '%');
+  if(progress === 100){
+    this.timer = setTimeout(function(){
+      this.elem.hide();
+    }.bind(this), 500);
+  }
+};
+
+LoadingBar.prototype.clearTimer = function(){
+  if(this.timer){
+    clearTimeout(this.timer);
+    this.timer = null;
+  }
 };
 
 module.exports = LoadingBar;


### PR DESCRIPTION
Fix bug preventing loading indicator from showing

Since we have a CSS animation on the width of the bar, and on a fast network the progress event usaully only fires once (at 100%), hiding the loading indicator eminently after calling `.end()` would not allow the animation to complete before the bar hidden.

This PR adds a timer to wait for the CSS animation before hiding the bar.

closes #392

__Desktop:__
![loading-indicator-desktop](https://user-images.githubusercontent.com/6282922/29948528-34443a76-8e64-11e7-9635-fbccfa9e0c02.gif)
__Mobile:__
![loading-indicator-mobile](https://user-images.githubusercontent.com/6282922/29948552-4fdd633e-8e64-11e7-869d-b7e5cf87c825.gif)
__Slow 3G Mobile:__
![loading-indicator-mobile-slow-3g](https://user-images.githubusercontent.com/6282922/29985151-95b688be-8f12-11e7-9541-ccf2b4252a0f.gif)


