### PR TITLE
use can-util/js/each/each instead of NodeList.prototype.forEach

### DIFF
--- a/sidebar/sidebar.events.js
+++ b/sidebar/sidebar.events.js
@@ -1,4 +1,5 @@
 var domData = require('can-util/dom/data/data');
+var each = require("can-util/js/each/each");
 
 module.exports = {
   '{element} inserted': 'animateElementsImmediately',
@@ -15,7 +16,7 @@ module.exports = {
   animateElementsImmediately: function() {
     var element = this.element;
     var unanimatedElements = element.querySelectorAll('.unanimated');
-    unanimatedElements.forEach(function(unanimatedElement) {
+    each(unanimatedElements, function(unanimatedElement) {
       unanimatedElement.classList.remove('unanimated');
     });
   },


### PR DESCRIPTION
Some browsers version dont support [```NodeList.prototype.forEach```](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach) like firefox < v50 which causes an error, using  ```can-util/js/each/each``` fixes the issue in the new sidebar.