### PR TITLE
Fix critical issues in IE 11

### DIFF
--- a/bit-docs.js
+++ b/bit-docs.js
@@ -15,9 +15,6 @@ module.exports = function(bitDocs){
                 configDependencies: [
                     "./node_modules/steal-conditional/conditional"
                 ]
-            },
-            devDependencies: {
-                "flexibility": "^2.0.1"
             }
         }
     });

--- a/make-example.js
+++ b/make-example.js
@@ -18,9 +18,6 @@ var siteConfig = {
                 configDependencies: [
                     "./node_modules/steal-conditional/conditional"
                 ]
-            },
-            devDependencies: {
-                "flexibility": "^2.0.1"
             }
         },
         dependencies: {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "can-util": "^3.0.10",
     "can-view-callbacks": "^3.2.2",
     "escape-html": "^1.0.3",
-    "flexibility": "^2.0.1",
     "jquery": "^3.1.1",
     "lodash": "^4.17.4",
     "lunr": "bit-docs/lunr.js#279-safari-exception",

--- a/static/canjs.js
+++ b/static/canjs.js
@@ -40,6 +40,12 @@ var $articleContainer,
 
 	// Override link behavior
 	$(document.body).on("click", "a", function(ev) {
+
+		// Fix relative URLs in IE 11
+		if (!ev.target.hostname && !this.hostname && !ev.target.protocol && !this.protocol) {
+			this.href = this.href;
+		}
+
 		var noModifierKeys = !ev.altKey && !ev.ctrlKey && !ev.metaKey && !ev.shiftKey,
 			sameHostname = (ev.target.hostname || this.hostname) === window.location.hostname,
 			sameProtocol = (ev.target.protocol || this.protocol) === window.location.protocol;

--- a/static/canjs.js
+++ b/static/canjs.js
@@ -143,7 +143,7 @@ function init() {
 			sidebarElement.insertBefore(socialContainer, sidebarElement.firstChild);
 
 			// Get rid of the old menu
-			currentMenu.remove();
+			currentMenu.parentNode.removeChild(currentMenu);
 		}, function(error) {
 			console.error('Failed to get search map with error:', error);
 		});

--- a/static/canjs.js
+++ b/static/canjs.js
@@ -1,4 +1,3 @@
-require("flexibility#?./needs-flexibility");
 require("./canjs.less!");
 var LoadingBar = require('./loading-bar.js');
 $ = require("jquery");
@@ -35,11 +34,6 @@ var $articleContainer,
 	//(used for fading in or not)
 	hasShownSearch = false;
 	init();
-
-	// flexbox for ie9/10
-	if(typeof flexibility !== 'undefined'){
-		flexibility(document.getElementById('everything'));
-	}
 
 	// prevent sidebar from changing width when header hides
 	$('#left').css('min-width', $('.top-left').width());

--- a/static/canjs.js
+++ b/static/canjs.js
@@ -288,6 +288,14 @@ function navigate(href, updateLocation) {
 			var $breadcrumb = $content.find(".breadcrumb");
 			var homeLink = $content.find(".logo > a").attr('href');
 
+			// Remove GitHub star buttons from the main body in IE
+			if (!!navigator.userAgent.match(/Trident/g) || !!navigator.userAgent.match(/MSIE/g)) {
+				var gitHubButtons = $article.find('.body .github-button');
+				gitHubButtons.each(function() {
+					this.classList.remove('github-button');
+				});
+			}
+
 			//root elements - use .filter; not .find
 			var $pathPrefixDiv = $content.filter("[path-prefix]");
 

--- a/static/header.less
+++ b/static/header.less
@@ -1,7 +1,6 @@
 .top-right-top {
   .flex;
   flex-direction: row-reverse;
-  -ms-flex-direction: row-reverse;
   flex-shrink: 0;
   height: @brand-height;
   justify-content: space-between;

--- a/static/layout.less
+++ b/static/layout.less
@@ -21,7 +21,6 @@
   }
 }
 #left {
-  -ms-flex-wrap: wrap;
   position: fixed;
   width: @sidebar-width;
   min-width: 0;
@@ -38,7 +37,6 @@
   }
 }
 #right {
-  -ms-flex-wrap: wrap;
   height: 100%;
   min-height: 100%;
   max-height: 100%;

--- a/static/mixins.less
+++ b/static/mixins.less
@@ -14,7 +14,6 @@
   border: 1px solid @border-color;
 }
 .flex {
-  -js-display: flex; // ie9/10 flexbox fix
   display: -webkit-box;
   display: -moz-box;
   display: -ms-flexbox;

--- a/static/mixins.less
+++ b/static/mixins.less
@@ -16,7 +16,6 @@
 .flex {
   display: -webkit-box;
   display: -moz-box;
-  display: -ms-flexbox;
   display: -webkit-flex;
   display: flex;
 }

--- a/static/module-list.less
+++ b/static/module-list.less
@@ -4,7 +4,7 @@
     margin: 0;
     list-style-type: none;
     list-style: none;
-    li { 
+    li {
      list-style-type: none;
      list-style: none;
     }
@@ -43,7 +43,7 @@
         position: relative;
         margin-left: 5px;
       }
-      > ul { 
+      > ul {
         .flex;
         justify-content: flex-end;
         margin-left: auto;
@@ -51,7 +51,7 @@
         flex-wrap: wrap;
         display: none;
         @media screen and (min-width: @breakpoint) {
-          display: unset;
+          display: block;
         }
         > li {
           display: inline-block;

--- a/templates/layout.mustache
+++ b/templates/layout.mustache
@@ -51,7 +51,7 @@
 		<script async defer src="https://buttons.github.io/buttons.js"></script>
 
 		<!-- root-level elements with attributes necessary for the app -->
-		<div path-prefix="{{pathToDest}}" />
-		
+		<div path-prefix="{{pathToDest}}"></div>
+
 	</body>
 </html>


### PR DESCRIPTION
This fixes the most critical issues in IE 11:

- Flexbox layout is fixed so content shows up
- The old sidebar was being kept alongside the new sidebar
- Links weren’t working in the new sidebar
- The API Docs page would take upwards of 30 seconds to load because of the GitHub star buttons, so those links are _not_ upgraded to buttons in IE anymore

Current CanJS.com:
<img width="1024" alt="screen shot 2017-11-15 at 3 53 17 pm" src="https://user-images.githubusercontent.com/10070176/32866577-4f0849ca-ca1d-11e7-8161-afc658c04981.png">

After updates (images are broken because the screenshot’s from this repo):
<img width="1024" alt="screen shot 2017-11-15 at 3 53 38 pm" src="https://user-images.githubusercontent.com/10070176/32866594-5e7d0634-ca1d-11e7-8f3c-c1288ea5d034.png">

Closes https://github.com/canjs/canjs/issues/3619