### PR TITLE
Style screenshots

### DIFF
--- a/static/screenshots.less
+++ b/static/screenshots.less
@@ -1,3 +1,9 @@
+.bit-docs-screenshot {
+	display: block;
+	margin: 0 auto;
+	max-width: 100%;
+}
+
 .screenshots {
 	span {
 		position: relative;
@@ -11,7 +17,7 @@
     text-decoration: none;
     font-size: 10px;
     max-width: 1024px;
-    
+
     &:hover, &:visited {
 			color: @gray;
 			text-decoration: none;


### PR DESCRIPTION
This small helper class helps improve the display of screenshots in the docs, specially making sure the image does not overflow the container.

took me a while to test the integration, but it works.
![screen shot 2018-01-23 at 4 38 54 pm](https://user-images.githubusercontent.com/724877/35306683-5829bece-005c-11e8-8faf-6e908031a3ca.png)

