### PR TITLE
remove styles competing with prism

### DIFF
--- a/static/article-title.less
+++ b/static/article-title.less
@@ -72,7 +72,8 @@ ul.title-links {
 
 	ol {
 		counter-reset: item;
-		margin: 0;
+		margin-left: @gutter*2;
+		margin-right: @gutter*2;
 		padding: 0;
 
 		li {

--- a/static/canjs.js
+++ b/static/canjs.js
@@ -546,6 +546,7 @@ function buildTOC() {
 	var $tocHeaders = getHeaders(true);
 
 	if (!$tocHeaders.length || $tocHeaders.length < 2) {
+		$tableOfContents.remove();
 		return;
 	}
 

--- a/static/content.less
+++ b/static/content.less
@@ -21,7 +21,7 @@ article {
     .border-radius(0);
   }
   code {
-	  
+
     .highlight {
 	    background: @highlight-color;
 	    padding: 3px 0;
@@ -53,13 +53,12 @@ article {
   pre code {
     background: none;
     display: block;
-    margin: @gutter;
     word-wrap: break-word;
     font-size: 15px;
     line-height: 20px;
     letter-spacing: 0;
     -webkit-font-smoothing: initial;
-    
+
     &.line-highlight {
       display: inline-block;
       min-width: 100%;

--- a/static/mixins.less
+++ b/static/mixins.less
@@ -30,7 +30,6 @@
   box-shadow: @horizontal @vertical @blur @color;
 }
 .code {
-  .border-radius;
   background: @border-color;
   font-size: .9em;
   color: @code-color;


### PR DESCRIPTION
There were a couple styles that competed with Prism for bit-docs/bit-docs-prettify#15.

Specifically: a margin on `article pre code` and a border radius on `code`.

With this fix (and with prism), it looks like:
![image](https://user-images.githubusercontent.com/980338/36230678-0883cbc2-1190-11e8-8e05-b93a6970fa23.png)
