### PR TITLE
Fix search

### DIFF
--- a/templates/search-results.stache
+++ b/templates/search-results.stache
@@ -14,23 +14,23 @@
 
   {{#if numResults}}
     <ul>
-      {{#each results as result}}
+      {{#each(results)}}
         <li>
-          <a href="{{docUrl(result.url)}}" title="{{result.name}}" class="result-name">
-            {{#if result.title}}{{result.title}}{{else}}{{result.name}}{{/if}}
-
-
-            {{#if result.title}}
-              {{^eq result.name result.title}}
+          <a href="{{docUrl(url)}}" title="{{name}}" class="result-name">
+            {{#if title}}
+              {{title}}
+              {{^eq name title}}
                 <span class="name">
-                  {{result.name}}
+                  {{name}}
                 </span>
               {{/eq}}
+            {{else}}
+              {{name}}
             {{/if}}
 
-            {{#if result.description}}
-              <div class="result-description" title="{{result.description}}">
-                {{{addTargetToExternalURLs(result.description, docUrl(result.url))}}}
+            {{#if description}}
+              <div class="result-description" title="{{description}}">
+                {{{addTargetToExternalURLs(description, docUrl(url))}}}
               </div>
             {{/if}}
           </a>

--- a/test/search.html
+++ b/test/search.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<title>bit-docs-html-canjs</title>
+<script>
+  FuncUnit = { frameMode: true };
+</script>
+<script src="../node_modules/steal/steal.js" main="test/search"></script>
+<div id="qunit-fixture"></div>

--- a/test/search.js
+++ b/test/search.js
@@ -1,6 +1,8 @@
 var QUnit = require('steal-qunit');
 var SearchControl = require('../static/search');
 var searchLogic = require('../static/search-logic');
+var searchBarTemplate = require('../templates/search-bar.mustache!steal-stache');
+var searchResultsTemplate = require('../templates/search-results.mustache!steal-stache');
 
 /* Helper function for finding a specific result */
 var indexOfPageInResults = function(pageName, results) {
@@ -14,28 +16,45 @@ var indexOfPageInResults = function(pageName, results) {
 /* Clear local storage */
 window.localStorage.clear();
 
-/* Create the search bar element */
-var searchBar = document.createElement('div');
-searchBar.id = 'search-bar';
-document.body.appendChild(searchBar);
+/* Render the search templates into the page */
+var qunitFixture = document.getElementById('qunit-fixture');
+qunitFixture.appendChild(searchBarTemplate());
+qunitFixture.appendChild(searchResultsTemplate());
 
 /* Create a new instance of the search control */
-var search = new SearchControl('#search-bar', {
+var search = new SearchControl('.search-bar', {
   pathPrefix: '../doc'
 });
 
 /* Tests */
 QUnit.module('search control');
 
-var readyToSearch = function() {
-  return search.searchEnginePromise.then(function(searchMap) {
-    searchLogic.indexData(search.convertSearchMapToIndexableItems(searchMap));
+var setUpSearchControl = search.searchEnginePromise.then(function(searchMap) {
+  return new Promise(function(resolve) {
+    // Wait for the search worker to be set up
+    setTimeout(function() {
+      resolve(searchLogic.indexData(search.convertSearchMapToIndexableItems(searchMap)));
+    }, 1000);
   });
-};
+});
+
+QUnit.test('Search results render', function(assert) {
+  var done = assert.async();
+  setUpSearchControl.then(function() {
+    search.search('can-');
+    setTimeout(function() {
+      var searchResultLis = document.querySelectorAll('.search-results li');
+      assert.equal(searchResultLis.length > 1, true, 'got more than 1 result');
+      var firstResultText = searchResultLis[0].querySelector('a').textContent.trim();
+      assert.notEqual(firstResultText, '', 'first result has text');
+      done();
+    }, 1000);
+  });
+});
 
 QUnit.test('Search for “about”', function(assert) {
   var done = assert.async();
-  readyToSearch().then(function() {
+  setUpSearchControl.then(function() {
     var results = searchLogic.search('about');
     assert.equal(results.length > 1, true, 'got more than 1 result');
     assert.equal(indexOfPageInResults('about', results), 0, 'first result is the About page');
@@ -45,7 +64,7 @@ QUnit.test('Search for “about”', function(assert) {
 
 QUnit.test('Search for “can-component”', function(assert) {
   var done = assert.async();
-  readyToSearch().then(function() {
+  setUpSearchControl.then(function() {
     var results = searchLogic.search('can-component');
     assert.equal(results.length > 1, true, 'got more than 1 result');
     assert.equal(indexOfPageInResults('can-component', results), 0, 'first result is the can-component page');
@@ -55,7 +74,7 @@ QUnit.test('Search for “can-component”', function(assert) {
 
 QUnit.test('Search for “can-connect”', function(assert) {
   var done = assert.async();
-  readyToSearch().then(function() {
+  setUpSearchControl.then(function() {
     var results = searchLogic.search('can-connect');
     assert.equal(results.length > 1, true, 'got more than 1 result');
     assert.equal(indexOfPageInResults('can-connect', results), 0, 'first result is the can-connect page');
@@ -65,7 +84,7 @@ QUnit.test('Search for “can-connect”', function(assert) {
 
 QUnit.test('Search for “helpers/', function(assert) {
   var done = assert.async();
-  readyToSearch().then(function() {
+  setUpSearchControl.then(function() {
     var results = searchLogic.search('helpers/');
     assert.equal(results.length > 1, true, 'got more than 1 result');
     done();
@@ -74,7 +93,7 @@ QUnit.test('Search for “helpers/', function(assert) {
 
 QUnit.test('Search for “Live Binding”', function(assert) {
   var done = assert.async();
-  readyToSearch().then(function() {
+  setUpSearchControl.then(function() {
     var results = searchLogic.search('Live Binding');
     assert.equal(results.length > 1, true, 'got more than 1 result');
     assert.equal(indexOfPageInResults('can-stache.Binding', results) < 2, true, 'first result is the can-stache Live Binding page');
@@ -84,7 +103,7 @@ QUnit.test('Search for “Live Binding”', function(assert) {
 
 QUnit.test('Search for “Play”', function(assert) {
   var done = assert.async();
-  readyToSearch().then(function() {
+  setUpSearchControl.then(function() {
     var results = searchLogic.search('Play');
     assert.equal(results.length > 0, true, 'got results');
     assert.equal(indexOfPageInResults('guides/recipes/playlist-editor', results), 0, 'first result is the “Playlist Editor (Advanced)” guide');
@@ -94,7 +113,7 @@ QUnit.test('Search for “Play”', function(assert) {
 
 QUnit.test('Search for “stache”', function(assert) {
   var done = assert.async();
-  readyToSearch().then(function() {
+  setUpSearchControl.then(function() {
     var results = searchLogic.search('stache');
     assert.equal(results.length > 1, true, 'got more than 1 result');
     assert.equal(indexOfPageInResults('can-stache', results), 0, 'first result is the can-stache page');
@@ -104,7 +123,7 @@ QUnit.test('Search for “stache”', function(assert) {
 
 QUnit.test('Search for “%special”', function(assert) {
   var done = assert.async();
-  readyToSearch().then(function() {
+  setUpSearchControl.then(function() {
     var results = searchLogic.search('%special');
     assert.equal(results.length > 0, true, 'got results');
     assert.equal(indexOfPageInResults('can-stache/keys/special', results), 0, 'first result is the can-stache/keys/special page');
@@ -114,7 +133,7 @@ QUnit.test('Search for “%special”', function(assert) {
 
 QUnit.test('Search for “define/map”', function(assert) {
   var done = assert.async();
-  readyToSearch().then(function() {
+  setUpSearchControl.then(function() {
     var results = searchLogic.search('define/map');
     assert.equal(results.length > 1, true, 'got more than 1 result');
     assert.equal(indexOfPageInResults('can-define/map/map', results), 0, 'first result is the can-define/map/map page');
@@ -122,10 +141,9 @@ QUnit.test('Search for “define/map”', function(assert) {
   });
 });
 
-
 QUnit.test('Speed while searching for can-*', function(assert) {
   var done = assert.async();
-  readyToSearch().then(function() {
+  setUpSearchControl.then(function() {
     var startTime = new Date();
     var results = searchLogic.search('can-zone');
     var totalTime = new Date() - startTime;


### PR DESCRIPTION
Due to not fixing some scope warnings before upgrading to CanJS 4, the search results weren’t rendering anything.

Before:
<img width="284" alt="before" src="https://user-images.githubusercontent.com/10070176/37182516-872e274e-22e6-11e8-91b1-1b94ef8678a4.png">

After:
<img width="299" alt="after" src="https://user-images.githubusercontent.com/10070176/37182521-8bff318c-22e6-11e8-854d-2b43d74d24d8.png">
