### PR TITLE
Fix issue with clicking docs in the sidebar

### DIFF
--- a/sidebar/page-model.js
+++ b/sidebar/page-model.js
@@ -76,6 +76,7 @@ var PageModel = DefineMap.extend({
       localStorage.setItem(storageKey, true);
     }
   },
+  collection: 'string',
   description: 'string',
   descriptionWithoutHTML: {
     get: function() {
@@ -129,9 +130,25 @@ var PageModel = DefineMap.extend({
       return ['group', 'prototype', 'static'].indexOf(this.type) !== -1;
     }
   },
+  isInCoreCollection: {
+    type: 'boolean',
+    default: false,
+    get: function() {
+      var collection = this.collection;
+      if (!collection) {
+        // Walk up the parents to find the collection
+        var parent = this.parentPage;
+        while (parent) {
+          collection = parent.collection;
+          parent = (collection) ? null : parent.parentPage;
+        }
+      }
+      return collection === 'can-core';
+    }
+  },
   name: {
     type: 'string',
-    value: ''
+    default: ''
   },
   order: 'number',
   parent: 'string',
@@ -232,7 +249,7 @@ var PageModel = DefineMap.extend({
   title: 'string',
   type: 'string',
   unsortedChildren: {
-    value: function() {
+    default: function() {
       return [];
     }
   },

--- a/sidebar/sidebar.viewmodel.js
+++ b/sidebar/sidebar.viewmodel.js
@@ -30,13 +30,13 @@ module.exports = DefineMap.extend({
   },
   pageMap: {
     type: 'any',
-    value: function() {
+    default: function() {
       return {};
     }
   },
   pathPrefix: {
     type: 'string',
-    value: '',
+    default: '',
     set: function(pathPrefix) {
       if (pathPrefix) {
         if (pathPrefix.substr(-1) !== '/') {
@@ -99,7 +99,7 @@ module.exports = DefineMap.extend({
         if (selectedPage.isCollapsed && selectedPage.visibleChildren.length === 0) {
           selectedPage.isCollapsed = false;
 
-        } else if (selectedPage.collection !== 'can-core') {
+        } else if (!selectedPage.isInCoreCollection) {
           // If the page is not in the core collection, walk up the parents to
           // make sure they are not collapsed.
           var parent = (selectedPage) ? selectedPage.parentPage : null;

--- a/sidebar/test.js
+++ b/sidebar/test.js
@@ -184,6 +184,15 @@ QUnit.test('When a Core package is selected, its parent should not automatically
   assert.ok(vm.shouldShowExpandCollapseButton(canObservablesPage), 'expand/collapse button is shown');
 });
 
+QUnit.test('When a child page of a Core package is selected, the package’s group should not automatically be expanded', function(assert) {
+  var vm = new ViewModel({searchMap: searchMap});
+  var canDefineTypesPage = vm.pageMap['can-define.types'];
+  var canObservablesPage = canDefineTypesPage.parentPage.parentPage.parentPage;
+  vm.selectedPage = canDefineTypesPage;
+  assert.ok(canObservablesPage.isCollapsed, 'parent page is collapsed');
+  assert.ok(vm.shouldShowExpandCollapseButton(canObservablesPage), 'expand/collapse button is shown');
+});
+
 QUnit.test('When a collapsed purpose group page with no visible children is selected, it should be expanded', function(assert) {
   var vm = new ViewModel({searchMap: searchMap});
   var domUtilitiesPage = vm.pageMap['can-dom-utilities'];


### PR DESCRIPTION
When the user clicks on the docs for a package within the Core collection, the purpose group that it’s in (e.g. Observables) shouldn’t expand automatically.

This fixes an issue where sections were expanding automatically when they shouldn’t, which fixed the issue with docs pages not loading correctly.

Fixes https://github.com/canjs/canjs/issues/4075

Gif of it working correctly now:
![sidebar bug](https://user-images.githubusercontent.com/10070176/38106626-791ee292-3344-11e8-83f0-2bc13eb2ae64.gif)
