### PR TITLE
Adds a height to the brand and version to overlap with hover state

### DIFF
--- a/static/header.less
+++ b/static/header.less
@@ -22,13 +22,15 @@
 .brand {
     display: flex;
     white-space: nowrap;
+    align-items: center;
     .dropdown {
         display:none;
     }
     .logo {
-        display: inline-block;
+        display: flex;
+        align-items: center;
         width: 60px;
-        height: 100%;
+        height: @brand-height;
         cursor: pointer;
         &:hover > a {
             opacity: .7;
@@ -82,11 +84,10 @@
             }
         }
         .version {
-            display: inline-flex;
-            vertical-align: top;
-            height: 100%;
-            padding-top: 7px;
+            display: flex;
+            align-items: center;
             font-size: 12px;
+            height: @brand-height;
             cursor: pointer;
             .version-number::after {
                 display: inline-block;


### PR DESCRIPTION
Changed branding and version to be `display: flex;`, to align center, and applied the header height variable to those sections to disallow a gap between the hit state and the hover state.

![hover-states](https://user-images.githubusercontent.com/4571457/57237092-7361bf80-6ff4-11e9-97b3-958e11135693.gif)
