### PR TITLE
i523 remove overflow from sidebar/#left column

### DIFF
--- a/static/layout.less
+++ b/static/layout.less
@@ -15,7 +15,6 @@
   -ms-grid-column-span: 1;
   grid-area: left-nav;
   height: calc(~"100vh - " @brand-height);// 53px header
-  overflow-y: scroll;
   position: fixed;
   scroll-behavior: smooth;
   top: @brand-height;


### PR DESCRIPTION
This removes setting `overflow` from `sidebar/#left` column from the style `layout.less`.
The scrollbar is visible without having `overflow-y` property.

Tested in `Firefox V66.0.5`, `Chrome V74.0.3729.131`, `Safari` and `Edge`.

Closes #523 