### PR TITLE
Add better metadata for SEO

### DIFF
--- a/templates/helpers.js
+++ b/templates/helpers.js
@@ -151,7 +151,7 @@ module.exports = function(docMap, options, getCurrent, helpers, OtherHandlebars)
         getLinkTitle: function(docObject) {
             var description = docObject.description || docObject.name;
             description = helpers.stripMarkdown(description);
-            return unescapeHTML(description);
+            return unescapeHTML(description).replace(/\n/g, " ").trim();
         },
         getShortTitle: function(docObject){
             return docMapInfo.getShortTitle(docObject);
@@ -159,9 +159,14 @@ module.exports = function(docMap, options, getCurrent, helpers, OtherHandlebars)
         getAltVersions: function() {
             return options.altVersions;
         },
+        getCodeRepository: function(docObject) {
+          if (docObject.package && docObject.package.repository) {
+            return docObject.package.repository.github || docObject.package.repository.url || docObject.package.repository;
+          }
+        },
         getDocumentTitle: function(docObject){
             var title = docMapInfo.getTitle(docObject) || 'CanJS';
-            if (title && title.toLowerCase() === 'canjs') {
+            if (docObject.name === 'canjs' || (title && title.toLowerCase() === 'canjs')) {
                 return title;
             }
             return 'CanJS - ' + title;

--- a/templates/layout.mustache
+++ b/templates/layout.mustache
@@ -4,7 +4,28 @@
 <head>
 	<meta charset="utf-8">
 	<title>{{getDocumentTitle .}}</title>
+	<meta name="description" content="{{getLinkTitle .}}">
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+	<meta property="og:image" content="https://www.bitovi.com/hubfs/open-source/os-canjs.png">
+	<meta property="og:description" content="{{getLinkTitle .}}">
+	<meta property="og:title" content="{{getDocumentTitle .}}">
+	<script type="application/ld+json">
+		{
+			"@context": "http://www.schema.org",
+			"@type": "SoftwareSourceCode",
+			"applicationCategory": "DeveloperApplication",
+			"brand": "Bitovi",
+			"category": "JavaScript Frameworks",
+			"codeRepository": "{{#with (getClosestWithPackage)}}{{getCodeRepository .}}{{/with}}",
+			"description": "{{getLinkTitle .}}",
+			"image": "https://www.bitovi.com/hubfs/open-source/os-canjs.png",
+			"license": "https://github.com/canjs/canjs/blob/master/license.md",
+			"logo": "https://www.bitovi.com/hubfs/open-source/os-canjs.png",
+			"name": "{{getDocumentTitle .}}",
+			"programmingLanguage": "JavaScript",
+			"softwareVersion" : "{{#with (getClosestWithPackage)}}{{package.version}}{{/with}}"
+		}
+	</script>
 	{{^devBuild}}
 		<link rel="stylesheet" type="text/css" href="{{pathToDest}}/static/bundles/bit-docs-site/static.css">
 		<link rel="shortcut icon" sizes="16x16 24x24 32x32 48x48 64x64" href="/docs/images/canjs_favicon.ico">


### PR DESCRIPTION
This adds `description`, `og:description`, `og:image`, `og:title`, and schema to every page.

I looked into the schema and decided that `SoftwareSourceCode` was a better `@type`, and then I changed the keys/values that are included based on that.

This PR doesn’t change the homepage title. That’ll be done in a separate PR.

Part of https://github.com/canjs/bit-docs-html-canjs/issues/497

Below is what the metadata looks like on a few pages:

## Homepage

<img width="618" alt="Screen Shot 2019-06-05 at 6 04 03 PM" src="https://user-images.githubusercontent.com/10070176/58999771-53244c80-87bc-11e9-8c59-6ffd055d4e4f.png">

## Info page (Setting Up CanJS)

<img width="615" alt="Screen Shot 2019-06-05 at 6 05 03 PM" src="https://user-images.githubusercontent.com/10070176/58999795-7818bf80-87bc-11e9-9ce4-2a045c26619b.png">

## Package page (can-define)

<img width="676" alt="Screen Shot 2019-06-05 at 6 05 55 PM" src="https://user-images.githubusercontent.com/10070176/58999820-967ebb00-87bc-11e9-9fc3-b4604422064f.png">

## Specific API page (PropDefinition in can-define)

<img width="675" alt="Screen Shot 2019-06-05 at 6 06 51 PM" src="https://user-images.githubusercontent.com/10070176/58999856-c8901d00-87bc-11e9-9a1b-644ce2d08195.png">
