### PR TITLE
Version selector always visible

### DIFF
--- a/static/header.less
+++ b/static/header.less
@@ -50,12 +50,48 @@
         }
     }
     .version {
+        display: none;
+    }
+}
+
+// ----- DROPDOWNS -----
+
+.brand {
+    .dropdown {
+        position: absolute;
+        top: 52px;
+        background-color: white;
+        border: 1px solid #ccc;
+        box-shadow: 0 6px 12px rgba(0,0,0,.175);
+    }
+
+    .logo {
+        margin: 0 @gutter 0 0;
+        &:hover .dropdown {
+            display: block;
+        }
+        .project-dropdown {
+            width: 180px;
+        }
+        .project-dropdown a {
+            color: black;
+            font-size: 14px;
+            padding: 12px 16px;
+            text-decoration: none;
+            display: block;
+            &:hover {
+                background-color: @light-gray-color;
+            }
+        }
+    }
+    .version {
         display: flex;
         align-items: center;
         font-size: 12px;
         height: @brand-height;
         padding-top: 7px;
         cursor: pointer;
+        margin: 0 @gutter/3 0 0;
         .version-number::after {
             display: inline-block;
             width: 15px;
@@ -73,7 +109,6 @@
             display: block;
         }
         .version-dropdown {
-            left: 100px;
             width: 100px;
         }
         .version-dropdown a {
@@ -88,77 +123,6 @@
     }
 }
 
-// ----- CANJS LOGO AND VERSION DESKTOP -----
-@media screen and (min-width: @breakpoint) {
-    .brand {
-        .dropdown {
-            position: absolute;
-            top: 52px;
-            background-color: white;
-            border: 1px solid #ccc;
-            box-shadow: 0 6px 12px rgba(0,0,0,.175);
-        }
-
-        .logo {
-            margin: 0 @gutter 0 0;
-
-            &:hover .dropdown {
-                display: block;
-            }
-            .project-dropdown {
-                left: 20px;
-                width: 180px;
-            }
-            .project-dropdown a {
-                color: black;
-                font-size: 14px;
-                padding: 12px 16px;
-                text-decoration: none;
-                display: block;
-                &:hover {
-                    background-color: @light-gray-color;
-                }
-            }
-        }
-        .version {
-            display: flex;
-            align-items: center;
-            font-size: 12px;
-            height: @brand-height;
-            padding-top: 7px;
-            cursor: pointer;
-            .version-number::after {
-                display: inline-block;
-                width: 15px;
-                height: 15px;
-                vertical-align: bottom;
-                content: '';
-                background-image: url(img/down_black.svg);
-                background-size: cover;
-                background-repeat: no-repeat;
-            }
-            &:hover > a {
-                opacity: .7;
-            }
-            &:hover .dropdown {
-                display: block;
-            }
-            .version-dropdown {
-                left: 100px;
-                width: 100px;
-            }
-            .version-dropdown a {
-                color: black;
-                padding: 5px 10px;
-                text-decoration: none;
-                display: block;
-                &:hover {
-                    background-color: @light-gray-color;
-                }
-            }
-        }
-    }
-}
 
 // ----- CHAT, FORUM, GITHUB STAR, TWITTER -----
 .top-right-links {

--- a/static/header.less
+++ b/static/header.less
@@ -35,6 +35,7 @@
         width: 60px;
         height: @brand-height;
         cursor: pointer;
+        margin: 0 @gutter 0 0;
         &:hover > a {
             opacity: .7;
         }
@@ -49,7 +50,41 @@
         }
     }
     .version {
-        display: none;
+        display: flex;
+        align-items: center;
+        font-size: 12px;
+        height: @brand-height;
+        padding-top: 7px;
+        cursor: pointer;
+        .version-number::after {
+            display: inline-block;
+            width: 15px;
+            height: 15px;
+            vertical-align: bottom;
+            content: '';
+            background-image: url(img/down_black.svg);
+            background-size: cover;
+            background-repeat: no-repeat;
+        }
+        &:hover > a {
+            opacity: .7;
+        }
+        &:hover .dropdown {
+            display: block;
+        }
+        .version-dropdown {
+            left: 100px;
+            width: 100px;
+        }
+        .version-dropdown a {
+            color: black;
+            padding: 5px 10px;
+            text-decoration: none;
+            display: block;
+            &:hover {
+                background-color: @light-gray-color;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Small screen
<img width="522" alt="Screen Shot 2019-06-13 at 8 45 19 AM" src="https://user-images.githubusercontent.com/381138/59447214-bcf1b700-8db7-11e9-963e-5f6be2d1e1a5.png">

Small screen brands
<img width="515" alt="Screen Shot 2019-06-13 at 8 45 34 AM" src="https://user-images.githubusercontent.com/381138/59447264-d09d1d80-8db7-11e9-8598-288208b248a7.png">

Small screen version
<img width="503" alt="Screen Shot 2019-06-13 at 8 45 47 AM" src="https://user-images.githubusercontent.com/381138/59447288-d98def00-8db7-11e9-8360-fc3194906ec5.png">

Responsive
![version-selector](https://user-images.githubusercontent.com/381138/59450822-ef52e280-8dbe-11e9-8fec-dcd9b9db3abb.gif)
