### PR TITLE
Make it so only the TOC area scrolls in the right sidebar

### DIFF
--- a/static/canjs.js
+++ b/static/canjs.js
@@ -173,7 +173,7 @@ function init() {
 		var newToc = document.createElement("bit-toc");
 		newToc.depth = getOutlineDepth();
 		newToc.headingsContainerSelector = "body";
-		newToc.scrollSelector = "#toc-sidebar";
+		newToc.scrollSelector = "#toc-sidebar nav";
 		newToc.highlight = function() {
 			var articleRect = this.article.getBoundingClientRect();
 			var buttons = this.buttons;
@@ -220,22 +220,22 @@ function init() {
 				// Check to see if it’s in viewport
 				var lastActiveOrCompletedRect = lastActiveOrCompleted.getBoundingClientRect();
 				var sidebarElement = this.outlineScrollElement;
-				var topInset = sidebarElement.getBoundingClientRect().top;// Main nav height
-				var viewportHeight = window.innerHeight;
+				var sidebarElementBoundingRect = sidebarElement.getBoundingClientRect();
+				var topInset = sidebarElementBoundingRect.top;// Main nav height
+				var visibleSidebarHeight = sidebarElementBoundingRect.height;// Not the entire height, just what’s visible in the viewport
 				var lastActiveOrCompletedRectIsInViewport = (
-					lastActiveOrCompletedRect.bottom <= viewportHeight &&
+					lastActiveOrCompletedRect.bottom <= visibleSidebarHeight &&
 					lastActiveOrCompletedRect.left >= 0 &&
 					lastActiveOrCompletedRect.left <= window.innerWidth &&
 					lastActiveOrCompletedRect.top >= topInset &&
-					lastActiveOrCompletedRect.top <= viewportHeight
+					lastActiveOrCompletedRect.top <= visibleSidebarHeight
 				);
 				if (lastActiveOrCompletedRectIsInViewport === false) {
 					// Scroll the sidebar so the highlighted element is in the viewport
-					var visibleSidebarHeight = sidebarElement.offsetHeight;// Not the entire height, just what’s visible in the viewport
-					var amountScrolledDownSidebar = sidebarElement.scrollTop;
-					var additionalScrollAmount = lastActiveOrCompletedRect.top - viewportHeight;
+					var amountScrolledDownSidebar = tocContainer.scrollTop;
+					var additionalScrollAmount = lastActiveOrCompletedRect.top - visibleSidebarHeight;
 					var amountToScroll = topInset + (visibleSidebarHeight / 2) + additionalScrollAmount + amountScrolledDownSidebar;
-					sidebarElement.scrollTop = amountToScroll;
+					tocContainer.scrollTop = amountToScroll;
 				}
 			}
 		};
@@ -258,7 +258,7 @@ function init() {
 		tocContainer.appendChild(newToc);
 
 		// Show the “On this page” title
-		var onThisPage = document.querySelector("#toc-sidebar h1");
+		var onThisPage = document.querySelector("#toc-sidebar nav h1");
 		onThisPage.classList.remove("hide");
 
 		// After the TOC loads, determine whether the “On this page” title should show
@@ -396,7 +396,7 @@ function navigate(href, updateLocation) {
 
 			// Scroll to the top of the page & TOC sidebar
 			setPageScrollTop(0);
-			$('#toc-sidebar').scrollTop(0);
+			$('#toc-sidebar nav').scrollTop(0);
 
 			var $article = $content.find("article");
 			var currentPage = $content.filter("#everything").attr("data-current-page");
@@ -487,7 +487,7 @@ function getOutlineDepth() {
 }
 
 function hideTOCSidebarScrollbar() {
-	var tocSidebar = document.querySelector("#toc-sidebar");
+	var tocSidebar = document.querySelector("#toc-sidebar nav");
 	if (tocSidebar.scrollHeight > tocSidebar.offsetHeight) {
 		tocSidebar.classList.add("hide-scrollbar");
 	} else {

--- a/static/layout.less
+++ b/static/layout.less
@@ -26,8 +26,9 @@
   -ms-grid-row: 2;
   -ms-grid-column: 1;
   -ms-grid-column-span: 1;
-  border-right: 3px solid #F4F4F4;
+  border-right: 3px solid @light-gray-color;
   grid-area: nav-sidebar;
+  scroll-behavior: smooth;
   @media screen and (max-width: @breakpoint) {
     width: @sidebar-width;
   }
@@ -45,14 +46,10 @@
   flex-grow: 1;
 }
 #toc-sidebar {
+  display: grid;
   grid-area: toc-sidebar;
-  @media (hover: hover) {
-    &.hide-scrollbar:not(:hover) {
-      margin-right: var(--scrollbar-width);
-      overflow: hidden;
-    }
-  }
-
+  grid-template-rows: 1fr auto;
+  padding: 0 @gutter*2 @gutter*2;
 }
 @media screen and (max-width: @breakpoint-sidebar-right){
   #toc-sidebar {
@@ -62,7 +59,6 @@
 #left, #toc-sidebar {
   height: calc(~"100vh - " @brand-height);// 53px header
   position: fixed;
-  scroll-behavior: smooth;
   top: @brand-height;
   transition: min-width @transition-speed ease;
   @media screen and (min-width: @breakpoint){

--- a/static/toc.less
+++ b/static/toc.less
@@ -1,5 +1,4 @@
 #toc-sidebar {
-	padding: 35px @gutter*2 0;
 	p {
 		font-size: 14px;
 		line-height: 1.5;
@@ -20,7 +19,19 @@
 			display: none;
 		}
 	}
+
 	nav {
+		overflow: auto;
+		padding: 35px 0 0;
+		scroll-behavior: smooth;
+
+		@media (hover: hover) {
+			&.hide-scrollbar:not(:hover) {
+				margin-right: var(--scrollbar-width);
+				overflow: hidden;
+			}
+		}
+
 		ul {
 			position: relative;
 			margin-top: 0;
@@ -99,50 +110,55 @@
 			border-left: 2px solid transparent;
 		}
 	}
-	.social-list {
-		display: block;
-		font-size: 14px;
-		padding-bottom: @gutter*2;
-		list-style: none;
-		margin-top: 0;
-		padding-left: 0;
+
+	.get-help {
+		border-top: 3px solid @light-gray-color;
+		padding: @gutter*2 0 0;
+
+		ul {
+			display: block;
+			font-size: 14px;
+			list-style: none;
+			margin: 0;
+			padding-left: 0;
+		}
 		li {
 			margin: @gutter/3 0;
-			a {
-				white-space: nowrap;
-				&:before {
-					display: inline-flex;
-					vertical-align: middle;
-					width: 30px;
-					height: 30px;
-					margin: 0 @gutter 0 0;
-					content: '';
-					background-repeat: no-repeat;
-				}
-				&.icon-slack:before {
-					background-image: url(img/icon-slack-gray.svg);
-				}
-				&.icon-github:before {
-					background-image: url(img/icon-github-gray.svg);
-				}
-				&.icon-twitter:before {
-					background-image: url(img/icon-twitter-gray.svg);
-				}
-				&.icon-forums:before {
-					background-image: url(img/icon-forums-gray.svg);
-				}
-				&.icon-blog:before {
-					background-image: url(img/icon-rss-gray.svg);
-				}
-				&.icon-youtube:before {
-					background-image: url(img/icon-youtube-gray.svg);
-				}
-				&.icon-meetup:before {
-					background-image: url(img/icon-meetup-gray.svg);
-				}
-				&.icon-stackoverflow:before {
-					background-image: url(img/icon-stackoverflow-gray.svg);
-				}
+		}
+		a {
+			white-space: nowrap;
+			&:before {
+				display: inline-flex;
+				vertical-align: middle;
+				width: 30px;
+				height: 30px;
+				margin: 0 @gutter 0 0;
+				content: '';
+				background-repeat: no-repeat;
+			}
+			&.icon-slack:before {
+				background-image: url(img/icon-slack-gray.svg);
+			}
+			&.icon-github:before {
+				background-image: url(img/icon-github-gray.svg);
+			}
+			&.icon-twitter:before {
+				background-image: url(img/icon-twitter-gray.svg);
+			}
+			&.icon-forums:before {
+				background-image: url(img/icon-forums-gray.svg);
+			}
+			&.icon-blog:before {
+				background-image: url(img/icon-rss-gray.svg);
+			}
+			&.icon-youtube:before {
+				background-image: url(img/icon-youtube-gray.svg);
+			}
+			&.icon-meetup:before {
+				background-image: url(img/icon-meetup-gray.svg);
+			}
+			&.icon-stackoverflow:before {
+				background-image: url(img/icon-stackoverflow-gray.svg);
 			}
 		}
 	}

--- a/templates/content.mustache
+++ b/templates/content.mustache
@@ -23,17 +23,17 @@
 
   </div>
   <div id="toc-sidebar" class="column">
-    <h1 class="hide">On this page</h1>
     <nav>
+      <h1 class="hide">On this page</h1>
     </nav>
-
-    <h1>Get help</h1>
-
-    <ul class="social-list">
-      <li><a href="https://www.bitovi.com/community/slack" target="_blank" class="icon-slack">Chat with us</a></li>
-      <li><a href="https://github.com/canjs/canjs/issues/new" target="_blank" class="icon-github">File an issue</a></li>
-      <li><a href="https://forums.bitovi.com/c/canjs" target="_blank" class="icon-forums">Ask questions</a></li>
-      <li><a href="https://www.bitovi.com/blog/topic/canjs" target="_blank" class="icon-blog">Read latest news</a></li>
-    </ul>
+    <div class="get-help">
+      <h1>Get help</h1>
+      <ul>
+        <li><a href="https://www.bitovi.com/community/slack" target="_blank" class="icon-slack">Chat with us</a></li>
+        <li><a href="https://github.com/canjs/canjs/issues/new" target="_blank" class="icon-github">File an issue</a></li>
+        <li><a href="https://forums.bitovi.com/c/canjs" target="_blank" class="icon-forums">Ask questions</a></li>
+        <li><a href="https://www.bitovi.com/blog/topic/canjs" target="_blank" class="icon-blog">Read latest news</a></li>
+      </ul>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
The Get Help section is now pinned to the bottom right of the sidebar. The TOC portion of the sidebar is its own independently-scrollable area.

@jamiemccue, please let me know if there’s anything you think we should change about the design/layout.

Fixes https://github.com/canjs/bit-docs-html-canjs/issues/530

## Short TOC

Even when the TOC is not very long, the Get Help links stick to the bottom of the right sidebar:

<img width="1292" alt="Screen Shot 2019-06-17 at 3 54 54 PM" src="https://user-images.githubusercontent.com/10070176/59642077-8221b300-9118-11e9-873c-f96f5c246a80.png">

## Long TOC

When the TOC is longer, it gets cut off by a border between it and the Get Help links:

<img width="1291" alt="Screen Shot 2019-06-17 at 3 55 08 PM" src="https://user-images.githubusercontent.com/10070176/59642115-a7aebc80-9118-11e9-8c51-c64fdd24775a.png">

## TOC in action

Here’s what it looks like when you scroll down the page and scroll inside the TOC:

![sidebar](https://user-images.githubusercontent.com/10070176/59642131-b5644200-9118-11e9-855f-0940b508d3ae.gif)

## Without a TOC

Some pages don’t have a TOC. The Get Help links still stick to the bottom:

<img width="1290" alt="Screen Shot 2019-06-17 at 3 58 42 PM" src="https://user-images.githubusercontent.com/10070176/59642180-e17fc300-9118-11e9-91fb-a51c949fdddd.png">
