### PR TITLE
Improve search results for terms like “restModel”

### DIFF
--- a/static/search.js
+++ b/static/search.js
@@ -4,7 +4,7 @@ var Control = require("can-control");
 var LoadingBar = require('./loading-bar');
 var searchResultsRenderer = require("../templates/search-results.stache!steal-stache");
 var joinURIs = require("can-util/js/join-uris/");
-var currentIndexVersion = 4;// Bump this whenever the index code is changed
+var currentIndexVersion = 5;// Bump this whenever the index code is changed
 
 var Search = Control.extend({
 

--- a/test/search.js
+++ b/test/search.js
@@ -141,6 +141,46 @@ QUnit.test('Search for “define/map”', function(assert) {
   });
 });
 
+QUnit.test('Search for “restModel”', function(assert) {
+  var done = assert.async();
+  setUpSearchControl.then(function() {
+    var results = searchLogic.search('restModel');
+    assert.equal(results.length > 1, true, 'got more than 1 result');
+    assert.equal(indexOfPageInResults('can-rest-model', results), 0, 'first result is the can-rest-model page');
+    done();
+  });
+});
+
+QUnit.test('Search for “QueryLogic”', function(assert) {
+  var done = assert.async();
+  setUpSearchControl.then(function() {
+    var results = searchLogic.search('QueryLogic');
+    assert.equal(results.length > 1, true, 'got more than 1 result');
+    assert.equal(indexOfPageInResults('can-query-logic', results), 0, 'first result is the can-query-logic page');
+    done();
+  });
+});
+
+QUnit.test('Search for “DefineList”', function(assert) {
+  var done = assert.async();
+  setUpSearchControl.then(function() {
+    var results = searchLogic.search('DefineList');
+    assert.equal(results.length > 1, true, 'got more than 1 result');
+    assert.equal(indexOfPageInResults('can-define/list/list', results), 0, 'first result is the can-define/list/list page');
+    done();
+  });
+});
+
+QUnit.test('Search for “DefineMap”', function(assert) {
+  var done = assert.async();
+  setUpSearchControl.then(function() {
+    var results = searchLogic.search('DefineMap');
+    assert.equal(results.length > 1, true, 'got more than 1 result');
+    assert.equal(indexOfPageInResults('can-define/map/map', results), 0, 'first result is the can-define/map/map page');
+    done();
+  });
+});
+
 QUnit.test('Speed while searching for can-*', function(assert) {
   var done = assert.async();
   setUpSearchControl.then(function() {


### PR DESCRIPTION
This improves the search results for queries such as restModel, QueryLogic, and DefineMap. This is done by:

1) Concatenating the module’s name (e.g. `can-define/map/map` is converted to `definemapmap`) and indexing the result
2) Giving preference to packages over other pages/results

Fixes https://github.com/canjs/bit-docs-html-canjs/issues/499

## restModel

### Before
<img width="350" alt="Screen Shot 2019-06-17 at 7 47 40 PM" src="https://user-images.githubusercontent.com/10070176/59649832-e18fbb00-9138-11e9-9cba-80ec8bf8a010.png">

### After
<img width="331" alt="Screen Shot 2019-06-17 at 7 49 34 PM" src="https://user-images.githubusercontent.com/10070176/59649905-1e5bb200-9139-11e9-9d35-5e775f510590.png">

## QueryLogic

### Before
<img width="345" alt="Screen Shot 2019-06-17 at 7 47 55 PM" src="https://user-images.githubusercontent.com/10070176/59649835-e6546f00-9138-11e9-8281-d96521159be2.png">

### After
<img width="341" alt="Screen Shot 2019-06-17 at 7 49 45 PM" src="https://user-images.githubusercontent.com/10070176/59649914-2582c000-9139-11e9-963d-0746f243396c.png">

## DefineMap

### Before
<img width="350" alt="Screen Shot 2019-06-17 at 7 48 10 PM" src="https://user-images.githubusercontent.com/10070176/59649843-ece2e680-9138-11e9-872a-d4077048234b.png">

### After
<img width="331" alt="Screen Shot 2019-06-17 at 7 50 00 PM" src="https://user-images.githubusercontent.com/10070176/59649929-29164700-9139-11e9-9f0f-13e2d72a27bb.png">
