### PR TITLE
Fix the animation when closing sections in the sidebar

### DIFF
--- a/static/sidebar.less
+++ b/static/sidebar.less
@@ -85,6 +85,9 @@ img.social-icon-small {
 						letter-spacing: 1px;
 						font-size: 11px;
 					}
+					&.unanimated:not(:first-child) a {
+						margin-top: 0;
+					}
 				}
 				ul {
 					// second


### PR DESCRIPTION
The top margin on the collection names (Core, Infrastructure, etc.) was not animating, causing a visible jump when sections were opened and closed.

Fixes https://github.com/canjs/bit-docs-html-canjs/issues/522

## Before
![before](https://user-images.githubusercontent.com/10070176/59872998-e4b0c400-934f-11e9-8dff-8f5da2badcac.gif)

## After
![after](https://user-images.githubusercontent.com/10070176/59873015-eaa6a500-934f-11e9-9737-11c9951976ff.gif)
