### PR TITLE
Remove capitalize page titles

### DIFF
--- a/static/canjs.js
+++ b/static/canjs.js
@@ -11,11 +11,6 @@ var can = require("can-namespace");
 // exposes canjs stuff so widgets can use it.
 window.can = can;
 
-// helpers
-var ucfirst = function (str) {
-	return str.charAt(0).toUpperCase() + str.slice(1);
-};
-
 var getParentModule = function(docObject) {
 	if (docObject.type === "module") {
 		return docObject;
@@ -334,7 +329,7 @@ function setDocTitle(docObject) {
 	} else {
 		var parentPage = docObject.parentPage;
 		while(parentPage) {
-			title += " | " + ucfirst(parentPage.title);
+			title += " | " + parentPage.title;
 			parentPage = parentPage.parentPage;
 		}
 	}

--- a/templates/helpers.js
+++ b/templates/helpers.js
@@ -3,11 +3,6 @@ var path = require("path");
 var escapeHTML = require("escape-html");
 var unescapeHTML = require("unescape-html");
 
-//helpers
-var ucfirst = function(str) {
-    return str.charAt(0).toUpperCase() + str.slice(1);
-};
-
 module.exports = function(docMap, options, getCurrent, helpers, OtherHandlebars){
     // create children lookup
     var childrenMap = makeChildrenMap(docMap);
@@ -211,7 +206,7 @@ module.exports = function(docMap, options, getCurrent, helpers, OtherHandlebars)
             } else {
                 var parentPage = docMap[docObject.parent];
                 while(parentPage) {
-                    title += " | " + ucfirst(parentPage.title);
+                    title += " | " + parentPage.title;
                     parentPage = docMap[parentPage.parent];
                 }
             }


### PR DESCRIPTION
This removes from the code the part that capitalize the first letter of page title:

#### Before
<img width="832" alt="Dynamic_Imports___Pages___Can-view-import___Views___API_Docs___CanJS_—_Build_CRUD_apps_in_fewer_lines_of_code_" src="https://user-images.githubusercontent.com/109013/59944446-b7057100-945c-11e9-96ef-e837f82ca69e.png">

#### After
<img width="736" alt="Dynamic_Imports___Pages___can-view-import___Views___API_Docs___CanJS" src="https://user-images.githubusercontent.com/109013/59944474-be2c7f00-945c-11e9-8c62-5e3a22c64a04.png">
