### PR TITLE
Add the by bitovi logo into mobile sidebar and reorganize the output

### DIFF
--- a/static/canjs.js
+++ b/static/canjs.js
@@ -162,7 +162,9 @@ function init() {
 			// Move the social-side-container to inside the new sidebar
 			var sidebarElement = document.querySelector('canjs-sidebar');
 			var socialContainer = currentMenu.querySelector('.social-side-container');
-			sidebarElement.insertBefore(socialContainer, sidebarElement.firstChild);
+			var bitoviContainer = currentMenu.querySelector('.by-bitovi-container');
+			sidebarElement.insertBefore(socialContainer, sidebarElement.secondChild);
+			sidebarElement.insertBefore(bitoviContainer, sidebarElement.thirdChild);
 
 			// Get rid of the old menu
 			currentMenu.parentNode.removeChild(currentMenu);

--- a/static/canjs.js
+++ b/static/canjs.js
@@ -163,8 +163,8 @@ function init() {
 			var sidebarElement = document.querySelector('canjs-sidebar');
 			var socialContainer = currentMenu.querySelector('.social-side-container');
 			var bitoviContainer = currentMenu.querySelector('.by-bitovi-container');
-			sidebarElement.insertBefore(socialContainer, sidebarElement.secondChild);
-			sidebarElement.insertBefore(bitoviContainer, sidebarElement.thirdChild);
+			sidebarElement.appendChild(socialContainer);
+			sidebarElement.appendChild(bitoviContainer);
 
 			// Get rid of the old menu
 			currentMenu.parentNode.removeChild(currentMenu);

--- a/static/header.less
+++ b/static/header.less
@@ -191,14 +191,6 @@
         .dropdown-menu {
             display: none;
         }
-        .bitovi.by-bitovi {
-            width: 100%;
-            height: 100%;
-            background: url(img/by-bitovi-logo.svg) no-repeat;
-            background-position: center;
-            background-size: contain;
-            color: rgba(0, 0, 0, 0);
-        }
     }
     &:hover {
         background: @border-color;
@@ -233,4 +225,12 @@
             }
         }
     }
+}
+.bitovi.by-bitovi {
+    width: 100%;
+    height: 100%;
+    background: url(img/by-bitovi-logo.svg) no-repeat;
+    background-position: center;
+    background-size: contain;
+    color: rgba(0, 0, 0, 0);
 }

--- a/static/sidebar.less
+++ b/static/sidebar.less
@@ -285,11 +285,3 @@ img.social-icon-small {
 	justify-content: center;
 	margin: 0 auto;
 }
-.bitovi.by-bitovi {
-	width: 100%;
-	height: 100%;
-	background: url(img/by-bitovi-logo.svg) no-repeat;
-	background-position: center;
-	background-size: contain;
-	color: rgba(0, 0, 0, 0);
-}

--- a/static/sidebar.less
+++ b/static/sidebar.less
@@ -66,7 +66,6 @@ img.social-icon-small {
 	.nav-menu {
 		display: block;
 		padding: @gutter @gutter*2 @gutter*2;
-		// Mobile sidebar By Bitovi logo
 		.by-bitovi-container {
 			width: 140px;
 			height: 30px;

--- a/static/sidebar.less
+++ b/static/sidebar.less
@@ -1,4 +1,7 @@
 // ----- SOCIAL BUTTONS FOR MOBILE VIEW -----
+.social-side-container {
+	margin: @gutter*1.5 0 @gutter 0;
+}
 ul.social-side {
 	margin: 0;
 	list-style: none;
@@ -62,7 +65,7 @@ img.social-icon-small {
 #left {
 	.nav-menu {
 		display: block;
-		padding: @gutter*2;
+		padding: @gutter @gutter*2 @gutter*2;
 		ul {
 			// first
 			padding: 0;
@@ -273,4 +276,21 @@ img.social-icon-small {
 				}
 			}
 		}
+}
+// Mobile sidebar By Bitovi logo
+.by-bitovi-container {
+	width: 140px;
+	height: 40px;
+	display: flex;
+	justify-content: center;
+	padding: 0 @gutter*2;
+	margin: 0 auto;
+}
+.bitovi.by-bitovi {
+	width: 100%;
+	height: 100%;
+	background: url(img/by-bitovi-logo.svg) no-repeat;
+	background-position: center;
+	background-size: contain;
+	color: rgba(0, 0, 0, 0);
 }

--- a/static/sidebar.less
+++ b/static/sidebar.less
@@ -1,6 +1,6 @@
 // ----- SOCIAL BUTTONS FOR MOBILE VIEW -----
 .social-side-container {
-	margin: @gutter*1.5 0 @gutter 0;
+	margin: @gutter*1.5 0;
 }
 ul.social-side {
 	margin: 0;
@@ -280,10 +280,9 @@ img.social-icon-small {
 // Mobile sidebar By Bitovi logo
 .by-bitovi-container {
 	width: 140px;
-	height: 40px;
+	height: 30px;
 	display: flex;
 	justify-content: center;
-	padding: 0 @gutter*2;
 	margin: 0 auto;
 }
 .bitovi.by-bitovi {

--- a/static/sidebar.less
+++ b/static/sidebar.less
@@ -66,6 +66,17 @@ img.social-icon-small {
 	.nav-menu {
 		display: block;
 		padding: @gutter @gutter*2 @gutter*2;
+		// Mobile sidebar By Bitovi logo
+		.by-bitovi-container {
+			width: 140px;
+			height: 30px;
+			display: flex;
+			justify-content: center;
+			margin: 0 auto;
+			@media screen and (min-width: @breakpoint){
+				display: none;
+			}
+		}
 		ul {
 			// first
 			padding: 0;
@@ -276,12 +287,4 @@ img.social-icon-small {
 				}
 			}
 		}
-}
-// Mobile sidebar By Bitovi logo
-.by-bitovi-container {
-	width: 140px;
-	height: 30px;
-	display: flex;
-	justify-content: center;
-	margin: 0 auto;
 }

--- a/templates/content.mustache
+++ b/templates/content.mustache
@@ -5,12 +5,15 @@
   <div id="left" class="column">
 
       <div class="nav-menu">
-        <div class="social-side-container">
-          {{>social.mustache}}
-        </div>
         {{#with (getCurrentTree)}}
             {{>menu.mustache}}
         {{/with}}
+        <div class="social-side-container">
+          {{>social.mustache}}
+        </div>
+        <div class="by-bitovi-container">
+          <a href="https://www.bitovi.com" class="bitovi by-bitovi">Bitovi</a>
+        </div>
       </div>
 
   </div>

--- a/templates/social.mustache
+++ b/templates/social.mustache
@@ -1,6 +1,6 @@
 <ul class="social-side">
   <li>
-    <a class="header-mobile github" href="https://github.com/canjs/canjs" target="_blank"><img class="social-icon-small" src="{{imagePath 'github.png'}}">Github</a>
+    <a class="header-mobile github" href="https://github.com/canjs/canjs" target="_blank"><img class="social-icon-small" src="{{imagePath 'github.png'}}">GitHub</a>
   </li>
   <li>
     <a class="header-mobile twitter" href="https://twitter.com/canjs" target="_blank"><img class="social-icon-small" src="{{imagePath 'twitter.png'}}">Twitter</a>

--- a/templates/social.mustache
+++ b/templates/social.mustache
@@ -14,3 +14,9 @@
     <a class="header-mobile" href="https://forums.bitovi.com/c/canjs" target="_blank">Forum</a>
   </li>
 </ul>
+<ul class="social-side">
+  <li>
+    <a class="header-mobile" href="https://www.bitovi.com/blog/topic/canjs" target="_blank">News</a>
+  </li>
+  <li></li>
+</ul>


### PR DESCRIPTION
- Kept the main navigation as is because it is quite deep
- Moved the social-links below the main nav
- Centered the _By Bitovi_ logo below the social-links

<img width="398" alt="Screen Shot 2019-06-24 at 3 08 23 PM" src="https://user-images.githubusercontent.com/381138/60055283-f537a600-9691-11e9-9c0d-87866787d2ad.png">
