### PR TITLE
Handle inline scripts ajax

### DIFF
--- a/static/canjs.js
+++ b/static/canjs.js
@@ -447,13 +447,16 @@ function navigate(href, updateLocation) {
 			// handle inline javascript code
 			// create a steal module on the fly
 			var scripts = $article[0].querySelectorAll('script[type="text/steal-module"]');
-			$.each(scripts, function (i, script) {
-				if (typeof steal !== 'undefined') {
-					if (script.id && !steal.loader.has(script.id)) {
-						steal.loader.define(script.id, script.innerText);
+			if (scripts && scripts.length > 0 ) {
+				$.each(scripts, function (i, script) {
+					if (typeof steal !== 'undefined') {
+						var moduleName = currentPage + "/" + i
+						if (!steal.loader.has(moduleName)) {
+							steal.loader.define(moduleName, script.innerText);
+						}
 					}
-				}
-			});
+				});
+			}
 
 			$(".top-right-links").replaceWith($headerLinks);
 			$("article").replaceWith($article);

--- a/static/canjs.js
+++ b/static/canjs.js
@@ -444,6 +444,17 @@ function navigate(href, updateLocation) {
 			//root elements - use .filter; not .find
 			var $pathPrefixDiv = $content.filter("[path-prefix]");
 
+			// handle inline javascript code
+			// create a steal module on the fly
+			var scripts = $article[0].querySelectorAll('script[type="text/steal-module"]');
+			$.each(scripts, function (i, script) {
+				if (typeof steal !== 'undefined') {
+					if (script.id && !steal.loader.has(script.id)) {
+						steal.loader.define(script.id, script.innerText);
+					}
+				}
+			});
+
 			$(".top-right-links").replaceWith($headerLinks);
 			$("article").replaceWith($article);
 			$(".logo > a").attr('href', homeLink);

--- a/static/canjs.js
+++ b/static/canjs.js
@@ -445,15 +445,13 @@ function navigate(href, updateLocation) {
 			var $pathPrefixDiv = $content.filter("[path-prefix]");
 
 			// handle inline javascript code
-			// create a steal module on the fly
+			// define a steal module on the fly
 			var scripts = $article[0].querySelectorAll('script[type="text/steal-module"]');
 			if (scripts && scripts.length > 0 ) {
-				$.each(scripts, function (i, script) {
-					if (typeof steal !== 'undefined') {
-						var moduleName = currentPage + "/" + i
-						if (!steal.loader.has(moduleName)) {
-							steal.loader.define(moduleName, script.innerText);
-						}
+				scripts.forEach(function (script, i) {
+					var moduleName = currentPage + "/" + i
+					if (!steal.loader.has(moduleName)) {
+						steal.loader.define(moduleName, script.innerText);
 					}
 				});
 			}


### PR DESCRIPTION
This fixes https://github.com/canjs/canjs/issues/5115

The logic behind this fix is to read the script tags with `steal-module` type and define a module on the fly using steal.

This is needed for the Counter demo essentially.