### PR TITLE
Remove headings from TOC

### DIFF
--- a/templates/signature.mustache
+++ b/templates/signature.mustache
@@ -15,13 +15,13 @@
   {{/if}}
   {{#returns}}
   <div class="returns">
-    <h3 class="returns-title">Returns</h3>
+    <h3 class="returns-title" data-skip>Returns</h3>
      <p>{{{makeReturn}}}: {{{makeHtml (makeLinks description)}}}</p>
   </div>
   {{/returns}}
   {{#if options.length}}
   <div class="options">
-  <h3 class="options-title">Options</h3>
+  <h3 class="options-title" data-skip>Options</h3>
     <ul>
     {{#options}}
       <li>


### PR DESCRIPTION
This adds `data-skip` attribute to the `Returns` and `Options` headings in signature in order to be removed from TOC.

Fixes #562