### PR TITLE
Updated type size, color and margin

### DIFF
--- a/static/article-title.less
+++ b/static/article-title.less
@@ -59,7 +59,6 @@ ul.title-links {
 .on-this-page-table {
 	display: inline-block;
 	margin-left: @gutter*2;
-	margin-bottom: @gutter*2;
 	border: none;
 
 	.on-this-page-title {

--- a/static/content.less
+++ b/static/content.less
@@ -156,3 +156,6 @@ blockquote{
 .body{
   margin: @gutter*2;
 }
+.cp_embed_wrapper {
+  margin-bottom: @gutter;
+}

--- a/static/type.less
+++ b/static/type.less
@@ -26,7 +26,8 @@ h2{
 	}
 }
 h3{
- 	color: lighten(@gray, 15%);
+	font-size: 25px;
+	color: lighten(@gray, 15%);
 	margin-top: @gutter*4;
 	font-weight: @font-weight-heading;
 }
@@ -40,6 +41,9 @@ a {
     text-decoration: underline;
   }
 }
-
+h4, h5, h6 {
+  font-size: 20px;
+  color: @gray;
+}
 
 

--- a/static/type.less
+++ b/static/type.less
@@ -1,49 +1,44 @@
-h1,h2,h3,h4,h5,h6 {
-  margin-top: 1em;
-  margin-bottom: @gutter;
-  font-weight: bold;
-  line-height: 1.4;
-  .border-bottom;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	color: lighten(@gray, 15%);
+	margin-top: 1em;
+	margin-bottom: @gutter;
+	font-weight: @font-weight-heading;
+	line-height: 1.4;
+	.border-bottom;
 }
-h1{
+h1 {
 	font-size: 45px;
-	color: lighten(@gray, 15%);
 	border: none;
-	margin-top:0px;
+	margin-top: 0px;
 	margin-bottom: 0px;
-	font-weight: @font-weight-heading;
 	word-wrap: break-word;
-	line-height: 1.0em;
-	margin-right: @gutter/2;
+	line-height: 1em;
+	margin-right: @gutter / 2;
 }
-h2{ 
+h2 {
 	font-size: 30px;
-	color: lighten(@gray, 15%);
 	margin-top: @gutter*4;
-	font-weight: @font-weight-heading;
-	code{
+	code {
 		color: lighten(@link-color, 5%) !important;
 	}
 }
-h3{
-	font-size: 25px;
-	color: lighten(@gray, 15%);
+h3 {
+	font-size: 24px;
 	margin-top: @gutter*4;
-	font-weight: @font-weight-heading;
 }
-p{
+p {
 	color: darken(@gray, 25%);
 }
 a {
-  color: @link-color;
-  text-decoration: none;
-  &:hover, &:active {
-    text-decoration: underline;
-  }
+	color: @link-color;
+	text-decoration: none;
+	&:hover,
+	&:active {
+		text-decoration: underline;
+	}
 }
-h4, h5, h6 {
-  font-size: 20px;
-  color: @gray;
-}
-
-


### PR DESCRIPTION
- [x] make h3-h6 headings larger and gray

<img width="798" alt="Screen Shot 2019-07-18 at 3 11 37 PM" src="https://user-images.githubusercontent.com/381138/61495658-70793880-a96e-11e9-83e1-2376cf7c2002.png">

- [x] Reduce margin-bottom .on-this-page-table

<img width="586" alt="Screen Shot 2019-07-18 at 3 13 17 PM" src="https://user-images.githubusercontent.com/381138/61495703-99013280-a96e-11e9-9cfc-20c9dcc0be6d.png">

- [x] Increase margin below codepen

<img width="855" alt="Screen Shot 2019-07-18 at 2 53 34 PM" src="https://user-images.githubusercontent.com/381138/61495724-a9b1a880-a96e-11e9-93ac-3ee6dfc54811.png">

