### PR TITLE
Fix applying new button styles on signatures

### DIFF
--- a/static/prism.less
+++ b/static/prism.less
@@ -1,4 +1,4 @@
-.body {
+#right {
 	div.code-toolbar {
 		line-height: 0;
 		> .toolbar {


### PR DESCRIPTION
Fixes #561

Before the fix:

<img width="797" alt="Screen Shot 2019-10-29 at 8 06 15 PM" src="https://user-images.githubusercontent.com/109013/67800588-cbe7b600-fa87-11e9-8d3c-38836fb7085d.png">

After:

<img width="809" alt="Screen Shot 2019-10-29 at 7 57 48 PM" src="https://user-images.githubusercontent.com/109013/67800626-de61ef80-fa87-11e9-93c2-facba903bb93.png">
