### PR TITLE
Handle searching for helper with terms start with '#'

### DIFF
--- a/static/search-logic.js
+++ b/static/search-logic.js
@@ -36,7 +36,12 @@ module.exports = {
 	},
 
 	search: function(value) {
+		var HELPER_START_PATTERN = /^#[a-z]/;
 		var searchTerm = value.toLowerCase();
+
+		if (HELPER_START_PATTERN.test(searchTerm)) {
+			searchTerm = value.substr(1, value.length)
+		}
 
 		//run the search
 		return searchEngine.query(function(q) {

--- a/test/search.js
+++ b/test/search.js
@@ -198,3 +198,13 @@ QUnit.test('Speed while searching for can-*', function(assert) {
     done();
   });
 });
+
+QUnit.test('Search for helper starting with "#xxx"', function(assert) {
+	var done = assert.async();
+	setUpSearchControl.then(function() {
+		var results = searchLogic.search('#let');
+		assert.equal(results.length > 1, true, 'Got results for #let');
+		assert.equal(indexOfPageInResults('can-stache.helpers.let', results), 0, 'first result is the can-stache.helpers.let page');
+		done();
+	});
+});


### PR DESCRIPTION
This fixes make possible to return results when searching for helper with terms like `#let` or `#if`.

fixes #589 