### PR TITLE
Favor core modules in search results

### DIFF
--- a/sidebar/test.js
+++ b/sidebar/test.js
@@ -179,7 +179,7 @@ QUnit.test('When a purpose group page is selected, its expand/collapse button sh
 
 QUnit.test('When a Core package is selected, its parent should not automatically be expanded', function(assert) {
   var vm = new ViewModel({searchMap: searchMap});
-  var canDefinePage = vm.pageMap['can-define'];
+  var canDefinePage = vm.pageMap['can-observable-object'];
   var canObservablesPage = canDefinePage.parentPage;
   vm.selectedPage = canDefinePage;
   assert.ok(canObservablesPage.isCollapsed, 'parent page is collapsed');
@@ -188,7 +188,7 @@ QUnit.test('When a Core package is selected, its parent should not automatically
 
 QUnit.test('When a child page of a Core package is selected, the package’s group should not automatically be expanded', function(assert) {
   var vm = new ViewModel({searchMap: searchMap});
-  var canDefineTypesPage = vm.pageMap['can-define.types'];
+  var canDefineTypesPage = vm.pageMap['can-observable-object/object.static.propertyDefaults'];
   var canObservablesPage = canDefineTypesPage.parentPage.parentPage.parentPage;
   vm.selectedPage = canDefineTypesPage;
   assert.ok(canObservablesPage.isCollapsed, 'parent page is collapsed');
@@ -206,7 +206,7 @@ QUnit.test('When a collapsed purpose group page with no visible children is sele
 QUnit.test('When docs in a package are selected, the group should still have the expand/collapse button', function(assert) {
   var vm = new ViewModel({searchMap: searchMap});
   var pageMap = vm.pageMap;
-  var canDefineTypesPage = pageMap['can-define.types'];
+  var canDefineTypesPage = pageMap['can-observable-object/object.static.propertyDefaults'];
   var canObservablesPage = pageMap['can-observables'];
   vm.selectedPage = canDefineTypesPage;
   assert.ok(vm.shouldShowExpandCollapseButton(canObservablesPage), 'expand/collapse button is shown');

--- a/static/search.js
+++ b/static/search.js
@@ -4,7 +4,7 @@ var Control = require("can-control");
 var LoadingBar = require('./loading-bar');
 var searchResultsRenderer = require("../templates/search-results.stache!steal-stache");
 var joinURIs = require("can-util/js/join-uris/");
-var currentIndexVersion = 5;// Bump this whenever the index code is changed
+var currentIndexVersion = 6;// Bump this whenever the index code is changed
 
 var Search = Control.extend({
 

--- a/test/search.js
+++ b/test/search.js
@@ -101,8 +101,8 @@ QUnit.test('Search for “helpers/', function(assert) {
 QUnit.test('Search for “Call Expression”', function(assert) {
   var done = assert.async();
   setUpSearchControl.then(function() {
-		var results = searchLogic.search('Call Expression');
-		assert.equal(results.length > 1, true, 'got more than 1 result');
+    var results = searchLogic.search('Call Expression');
+    assert.equal(results.length > 1, true, 'got more than 1 result');
     assert.equal(indexOfPageInResults('can-stache/expressions/call', results) < 2, true, 'first result is the can-stache Call Expression page');
     done();
   });
@@ -111,7 +111,7 @@ QUnit.test('Search for “Call Expression”', function(assert) {
 QUnit.test('Search for “Play”', function(assert) {
   var done = assert.async();
   setUpSearchControl.then(function() {
-		var results = searchLogic.search('Play');
+    var results = searchLogic.search('Play');
     assert.equal(results.length > 0, true, 'got results');
     assert.equal(indexOfPageInResults('guides/recipes/playlist-editor', results), 0, 'first result is the “Playlist Editor (Advanced)” guide');
     done();
@@ -131,7 +131,7 @@ QUnit.test('Search for “stache”', function(assert) {
 QUnit.test('Search for “{{#expression}}', function(assert) {
   var done = assert.async();
   setUpSearchControl.then(function() {
-		var results = searchLogic.search('{{#expression}}');
+    var results = searchLogic.search('{{#expression}}');
     assert.equal(results.length > 0, true, 'got results');
     assert.equal(indexOfPageInResults('can-stache.tags.section', results), 0, 'first result is the can-stache.tags.section page');
     done();
@@ -141,7 +141,7 @@ QUnit.test('Search for “{{#expression}}', function(assert) {
 QUnit.test('Search for “define/map”', function(assert) {
   var done = assert.async();
   setUpSearchControl.then(function() {
-		var results = searchLogic.search('define/map');
+    var results = searchLogic.search('define/map');
     assert.equal(results.length > 1, true, 'got more than 1 result');
     assert.equal(indexOfPageInResults('can-define/map/map', results), 0, 'first result is the can-define/map/map page');
     done();
@@ -171,7 +171,7 @@ QUnit.test('Search for “QueryLogic”', function(assert) {
 QUnit.test('Search for “DefineList”', function(assert) {
   var done = assert.async();
   setUpSearchControl.then(function() {
-		var results = searchLogic.search('DefineList');
+    var results = searchLogic.search('DefineList');
     assert.equal(results.length > 1, true, 'got more than 1 result');
     assert.equal(indexOfPageInResults('can-define/list/list', results), 0, 'first result is the can-define/list/list page');
     done();
@@ -200,21 +200,21 @@ QUnit.test('Speed while searching for can-*', function(assert) {
 });
 
 QUnit.test('Search for helper starting with "#xxx"', function(assert) {
-	var done = assert.async();
-	setUpSearchControl.then(function() {
-		var results = searchLogic.search('#let');
-		assert.equal(results.length > 1, true, 'Got results for #let');
-		assert.equal(indexOfPageInResults('can-stache.helpers.let', results), 0, 'first result is the can-stache.helpers.let page');
-		done();
-	});
+  var done = assert.async();
+  setUpSearchControl.then(function() {
+    var results = searchLogic.search('#let');
+    assert.equal(results.length > 1, true, 'Got results for #let');
+    assert.equal(indexOfPageInResults('can-stache.helpers.let', results), 0, 'first result is the can-stache.helpers.let page');
+    done();
+  });
 });
 
 QUnit.test("Prioritize core packages in search results", function(assert) {
-	var done = assert.async();
-	setUpSearchControl.then(function() {
-		var results = searchLogic.search('types');
-		assert.equal(results.length > 1, true, 'Got results for type');
-		assert.equal(indexOfPageInResults('can-type', results), 0, 'first result is the can-type page');
-		done();
-	});
+  var done = assert.async();
+  setUpSearchControl.then(function() {
+    var results = searchLogic.search('types');
+    assert.equal(results.length > 1, true, 'Got results for type');
+    assert.equal(indexOfPageInResults('can-type', results), 0, 'first result is the can-type page');
+    done();
+  });
 });

--- a/test/search.js
+++ b/test/search.js
@@ -101,8 +101,8 @@ QUnit.test('Search for “helpers/', function(assert) {
 QUnit.test('Search for “Call Expression”', function(assert) {
   var done = assert.async();
   setUpSearchControl.then(function() {
-    var results = searchLogic.search('Call Expression');
-    assert.equal(results.length > 1, true, 'got more than 1 result');
+		var results = searchLogic.search('Call Expression');
+		assert.equal(results.length > 1, true, 'got more than 1 result');
     assert.equal(indexOfPageInResults('can-stache/expressions/call', results) < 2, true, 'first result is the can-stache Call Expression page');
     done();
   });
@@ -111,7 +111,7 @@ QUnit.test('Search for “Call Expression”', function(assert) {
 QUnit.test('Search for “Play”', function(assert) {
   var done = assert.async();
   setUpSearchControl.then(function() {
-    var results = searchLogic.search('Play');
+		var results = searchLogic.search('Play');
     assert.equal(results.length > 0, true, 'got results');
     assert.equal(indexOfPageInResults('guides/recipes/playlist-editor', results), 0, 'first result is the “Playlist Editor (Advanced)” guide');
     done();
@@ -131,7 +131,7 @@ QUnit.test('Search for “stache”', function(assert) {
 QUnit.test('Search for “{{#expression}}', function(assert) {
   var done = assert.async();
   setUpSearchControl.then(function() {
-    var results = searchLogic.search('{{#expression}}');
+		var results = searchLogic.search('{{#expression}}');
     assert.equal(results.length > 0, true, 'got results');
     assert.equal(indexOfPageInResults('can-stache.tags.section', results), 0, 'first result is the can-stache.tags.section page');
     done();
@@ -141,7 +141,7 @@ QUnit.test('Search for “{{#expression}}', function(assert) {
 QUnit.test('Search for “define/map”', function(assert) {
   var done = assert.async();
   setUpSearchControl.then(function() {
-    var results = searchLogic.search('define/map');
+		var results = searchLogic.search('define/map');
     assert.equal(results.length > 1, true, 'got more than 1 result');
     assert.equal(indexOfPageInResults('can-define/map/map', results), 0, 'first result is the can-define/map/map page');
     done();
@@ -171,7 +171,7 @@ QUnit.test('Search for “QueryLogic”', function(assert) {
 QUnit.test('Search for “DefineList”', function(assert) {
   var done = assert.async();
   setUpSearchControl.then(function() {
-    var results = searchLogic.search('DefineList');
+		var results = searchLogic.search('DefineList');
     assert.equal(results.length > 1, true, 'got more than 1 result');
     assert.equal(indexOfPageInResults('can-define/list/list', results), 0, 'first result is the can-define/list/list page');
     done();
@@ -205,6 +205,16 @@ QUnit.test('Search for helper starting with "#xxx"', function(assert) {
 		var results = searchLogic.search('#let');
 		assert.equal(results.length > 1, true, 'Got results for #let');
 		assert.equal(indexOfPageInResults('can-stache.helpers.let', results), 0, 'first result is the can-stache.helpers.let page');
+		done();
+	});
+});
+
+QUnit.test("Prioritize core packages in search results", function(assert) {
+	var done = assert.async();
+	setUpSearchControl.then(function() {
+		var results = searchLogic.search('types');
+		assert.equal(results.length > 1, true, 'Got results for type');
+		assert.equal(indexOfPageInResults('can-type', results), 0, 'first result is the can-type page');
 		done();
 	});
 });


### PR DESCRIPTION
This adds prioritize `can-core` collection modules in search results.

Other collection modules needed special boost also, so a specific boost was added to other collections, like `function`, `typedef` or pages.

Closes #575 